### PR TITLE
feat/#5: 메인 페이지 오늘의 추천 공연 UI

### DIFF
--- a/src/assets/chevrons/chevron-right.svg
+++ b/src/assets/chevrons/chevron-right.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9 18.2234L14.6854 12.9305C15.1049 12.54 15.1049 11.9068 14.6854 11.5163L9 6.22339" stroke="#F5F5F5" stroke-width="1.5" stroke-linecap="round"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 18L14.6854 12.7071C15.1049 12.3166 15.1049 11.6834 14.6854 11.2929L9 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
 </svg>

--- a/src/components/main/Magazine.tsx
+++ b/src/components/main/Magazine.tsx
@@ -1,0 +1,36 @@
+import ChevronRight from '@/assets/chevrons/chevron-right.svg?react';
+import PlayTag from './PlayTag';
+import RecommendedPlay from './RecommendedPlay';
+import {mockRecommendedPlays} from '@/mocks/mockRecommendedPlays';
+
+export default function Magazine() {
+  const categories = [
+    ['창작 뮤지컬', '오리지널/내한 뮤지컬'],
+    ['리미티드 런', '아동/가족 뮤지컬'],
+  ];
+  return (
+    <div className='flex flex-col w-full bg-white rounded-[20px] pt-[30px] pl-[22px] pb-[20px] gap-20'>
+      <div className='w-full flex justify-between items-center'>
+        <h1 className='text-gray-30 font-bold text-2xl'>오늘의 추천 공연</h1>
+        <div className='flex items-center cursor-pointer mr-[27px]'>
+          <h2 className='text-[16px] font-medium text-primary-50'>
+            자세히 보기
+          </h2>
+          <ChevronRight className='text-primary-50' />
+        </div>
+      </div>
+
+      {categories.map((row, index) => (
+        <div key={index} className='flex flex-col gap-19'>
+          <PlayTag categories={row} />
+          <RecommendedPlay
+            plays={[
+              ...mockRecommendedPlays[row[0]],
+              ...mockRecommendedPlays[row[1]],
+            ]}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/main/PlayTag.tsx
+++ b/src/components/main/PlayTag.tsx
@@ -1,0 +1,23 @@
+/** 
+ * 인터파크 기준 카테고리 명을 Props로 받는 컴포넌트
+ * 
+    인터파크 기준 카테고리 : 창작 뮤지컬, 오리지널/내한 뮤지컬, 라이선스 뮤지컬, 넘버별 퍼포먼스, 아동/가족 뮤지컬
+    리미티드런, 스테디셀러
+ */
+
+interface PlayTagProps {
+  categories: string[];
+}
+export default function PlayTag({categories}: PlayTagProps) {
+  return (
+    <div className='flex h-50 gap-10 overflow-x-auto scrollbar-hide'>
+      {categories.map((category, index) => (
+        <div
+          key={index}
+          className='h-44 rounded-[10px] bg-primary-20 text-[20px] text-white font-normal whitespace-nowrap px-[21px] py-8 flex items-center'>
+          # {category}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/main/RecommendedPlay.tsx
+++ b/src/components/main/RecommendedPlay.tsx
@@ -1,0 +1,28 @@
+/**
+ * 추천 극을 보여주는 컴포넌트
+ * 공연 상세 내용을 연결합니다.
+ */
+
+import {useHorizontalScroll} from '@/hooks/useHorizontalScroll';
+import RecommendedPlayItem from './RecommendedPlayItem';
+
+interface Play {
+  id: number;
+  title: string;
+  imageUrl?: string;
+}
+
+interface RecommendedPlayProps {
+  plays: Play[];
+}
+
+export default function RecommendedPlay({plays}: RecommendedPlayProps) {
+  const listWrapperRef = useHorizontalScroll();
+  return (
+    <ul className='flex gap-18 overflow-x-auto ' ref={listWrapperRef}>
+      {plays.map((play) => (
+        <RecommendedPlayItem key={play.id} title={play.title} />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/main/RecommendedPlayItem.tsx
+++ b/src/components/main/RecommendedPlayItem.tsx
@@ -1,0 +1,25 @@
+import ChevronRight from '@/assets/chevrons/chevron-right.svg?react';
+
+interface RecommendedPlayItemProps {
+  title: string;
+}
+
+export default function RecommendedPlayItem({title}: RecommendedPlayItemProps) {
+  return (
+    <li className='flex flex-col min-w-[200px] gap-10 shrink-0'>
+      <div className='w-full min-h-[227px] bg-gray-10 rounded-[20px]'>
+        {/** 이미지 자리 */}
+        추천극 임시
+      </div>
+      <div className='w-full flex items-center justify-between'>
+        <h2 className='w-[96px] text-gray-30 font-bold text-[16px]  whitespace-nowrap '>
+          {title}
+        </h2>
+        <div className='flex flex-row cursor-pointer '>
+          <h2 className='font-medium text-[16px] text-primary-50'>보러가기</h2>
+          <ChevronRight className='text-primary-50' />
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/components/main/WeekCalendar.tsx
+++ b/src/components/main/WeekCalendar.tsx
@@ -89,7 +89,7 @@ export default function WeekCalendar({
   };
 
   return (
-    <div className='flex flex-col w-[570px] min-h-[263px] px-[38px] py-[22px] bg-white rounded-[20px] -mt-[8px] relative z-0 m-16 gap-[10px]'>
+    <div className='flex flex-col w-full min-h-[263px] px-[38px] py-[22px] bg-white rounded-[20px] -mt-[20px] relative z-0 gap-[10px]'>
       <div className='flex flex-col gap-[30px]'>
         <span className='font-bold text-[24px]'>전체 일정 달력</span>
         <div className='flex justify-between w-full'>

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -1,0 +1,31 @@
+/** 마우스 휠 가로 스크롤을 위한 커스텀 훅 */
+
+import {useCallback, useEffect, useRef} from 'react';
+
+export const useHorizontalScroll = () => {
+  const listWrapperRef = useRef<HTMLUListElement>(null);
+
+  const handleWheel = useCallback((e: WheelEvent) => {
+    if (!listWrapperRef.current) return;
+
+    // 마우스 휠만 가로 스크롤로 변환
+    if (Math.abs(e.deltaX) < 1 && Math.abs(e.deltaY) > 0) {
+      listWrapperRef.current.scrollLeft += e.deltaY;
+      e.preventDefault();
+    }
+  }, []);
+
+  useEffect(() => {
+    const container = listWrapperRef.current;
+
+    if (container) {
+      container.addEventListener('wheel', handleWheel, {passive: false});
+
+      return () => {
+        container.removeEventListener('wheel', handleWheel);
+      };
+    }
+    return () => {};
+  }, [handleWheel]);
+  return listWrapperRef;
+};

--- a/src/mocks/mockRecommendedPlays.ts
+++ b/src/mocks/mockRecommendedPlays.ts
@@ -1,0 +1,43 @@
+type Performance = {
+  id: number;
+  title: string;
+  imageUrl?: string;
+};
+
+export const mockRecommendedPlays: Record<string, Performance[]> = {
+  '창작 뮤지컬': [
+    {
+      id: 1,
+      title: '번지점프를 하다',
+    },
+    {
+      id: 2,
+      title: '빨래',
+    },
+    {
+      id: 3,
+      title: '어쩌면 해피엔딩',
+    },
+  ],
+
+  '오리지널/내한 뮤지컬': [
+    {
+      id: 4,
+      title: '위키드',
+    },
+    {
+      id: 5,
+      title: '레미제라블',
+    },
+  ],
+
+  '리미티드 런': [{id: 6, title: '더 픽'}],
+
+  '아동/가족 뮤지컬': [
+    {id: 7, title: '겨울왕국'},
+    {
+      id: 8,
+      title: '무지개 물고기',
+    },
+  ],
+};

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 import Header from '@/components/main/Header';
 import WeekCalendar from '@/components/main/WeekCalendar';
 import type {Schedule} from '@/types/schedule';
+import Magazine from '@/components/main/Magazine';
 
 export default function MainPage() {
   /** mock user data */
@@ -48,17 +49,20 @@ export default function MainPage() {
   };
 
   return (
-    <div className='w-full bg-black flex flex-col items-center '>
+    <div className='w-full max-w-[600px] bg-black flex flex-col items-center '>
       <Header isLoggedIn={isLoggedIn} username={username} />
-      <WeekCalendar
-        isLoggedIn={isLoggedIn}
-        schedules={schedules}
-        onLikeClick={handleLikeClick}
-        onScheduleClick={(schedule) =>
-          console.log('Schedule clicked:', schedule)
-        }
-        onViewMore={() => console.log('View more clicked')}
-      />
+      <div className='p-[14px] flex flex-col w-full gap-16'>
+        <WeekCalendar
+          isLoggedIn={isLoggedIn}
+          schedules={schedules}
+          onLikeClick={handleLikeClick}
+          onScheduleClick={(schedule) =>
+            console.log('Schedule clicked:', schedule)
+          }
+          onViewMore={() => console.log('View more clicked')}
+        />
+        <Magazine />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#5 


<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
메인 페이지에서 오늘의 추천 공연 UI를 구현했습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="529" height="713" alt="image" src="https://github.com/user-attachments/assets/4725535c-f4c6-4960-ae9a-80b811e821df" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
카드형 컴포넌트 스크롤을 마우스 휠/트랙패드 두 가지로 스크롤 가능하게 구현했는데, 추후에 데이터가 많아지면 Swiper 라이브러리 사용해서 리팩토링해도 좋을 것 같습니다! 

<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->