### PR TITLE
refactor/#13: Schedule 컴포넌트 구조 리팩토링 및 의존성 분리

### DIFF
--- a/src/components/main/ScheduleItem.tsx
+++ b/src/components/main/ScheduleItem.tsx
@@ -5,24 +5,19 @@
 import EmptyHeart from '@/assets/hearts/empty-heart.svg';
 import FullHeart from '@/assets/hearts/full-heart.svg';
 
-interface Schedule {
-  id: string;
-  category: string;
-  title: string;
-  isLike?: boolean;
-  date: Date;
-}
-
 interface ScheduleItemProps {
-  schedule: Schedule;
-  onLikeClick?: (schedule: Schedule) => void;
+  title: string;
+  category: string;
+  isLike?: boolean;
+  onLikeClick?: () => void;
 }
 
 export default function ScheduleItem({
-  schedule,
+  title,
+  category,
+  isLike,
   onLikeClick,
 }: ScheduleItemProps) {
-  const {category, title, isLike} = schedule;
   return (
     <div className='flex justify-between px-[12.5px] py-[6.5px] bg-[#FFFFFF]'>
       {/* 왼쪽: 카테고리 + 제목 */}
@@ -35,7 +30,7 @@ export default function ScheduleItem({
         </div>
       </div>
       {/* 오른쪽: 하트 */}
-      <button onClick={() => onLikeClick?.(schedule)}>
+      <button onClick={onLikeClick}>
         <img src={isLike ? FullHeart : EmptyHeart} alt='heart' />
       </button>
     </div>

--- a/src/components/main/ScheduleList.tsx
+++ b/src/components/main/ScheduleList.tsx
@@ -22,8 +22,10 @@ export default function ScheduleList({
       {schedules.map((schedule) => (
         <ScheduleItem
           key={schedule.id}
-          schedule={schedule}
-          onLikeClick={onLikeClick}
+          title={schedule.title}
+          category={schedule.category}
+          isLike={schedule.isLike}
+          onLikeClick={() => onLikeClick?.(schedule)}
         />
       ))}
 

--- a/src/mocks/mockSchedules.ts
+++ b/src/mocks/mockSchedules.ts
@@ -1,0 +1,32 @@
+import type {Schedule} from '@/types/schedule';
+
+export const mockSchedules: Schedule[] = [
+  {
+    id: '0',
+    category: '연극',
+    title: '<어쩌구 연극> 3차 티켓팅',
+    isLike: false,
+    date: new Date('2025-07-10'),
+  },
+  {
+    id: '1',
+    category: '연극',
+    title: '<어쩌구 연극> 3차 티켓팅',
+    isLike: true,
+    date: new Date('2025-07-10'),
+  },
+  {
+    id: '2',
+    category: '콘서트',
+    title: '<어쩌구 콘서트> 3차 티켓팅',
+    isLike: true,
+    date: new Date('2025-07-13'),
+  },
+  {
+    id: '3',
+    category: '뮤지컬',
+    title: '<어쩌구 뮤지컬> 3차 티켓팅',
+    isLike: false,
+    date: new Date('2025-07-13'),
+  },
+];

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -3,42 +3,14 @@ import Header from '@/components/main/Header';
 import WeekCalendar from '@/components/main/WeekCalendar';
 import type {Schedule} from '@/types/schedule';
 import Magazine from '@/components/main/Magazine';
+import {mockSchedules} from '@/mocks/mockSchedules';
 
 export default function MainPage() {
   /** mock user data */
   const isLoggedIn = true;
   const username = '민아';
 
-  const [schedules, setSchedules] = useState<Schedule[]>([
-    {
-      id: '0',
-      category: '연극',
-      title: '<어쩌구 연극> 3차 티켓팅',
-      isLike: false,
-      date: new Date('2025-07-10'),
-    },
-    {
-      id: '1',
-      category: '연극',
-      title: '<어쩌구 연극> 3차 티켓팅',
-      isLike: true,
-      date: new Date('2025-07-10'),
-    },
-    {
-      id: '2',
-      category: '콘서트',
-      title: '<어쩌구 콘서트> 3차 티켓팅',
-      isLike: true,
-      date: new Date('2025-07-11'),
-    },
-    {
-      id: '3',
-      category: '뮤지컬',
-      title: '<어쩌구 뮤지컬> 3차 티켓팅',
-      isLike: false,
-      date: new Date('2025-07-12'),
-    },
-  ]);
+  const [schedules, setSchedules] = useState<Schedule[]>(mockSchedules);
 
   const handleLikeClick = (clicked: Schedule) => {
     setSchedules((prev) =>


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
close #13

<br><br>

## 📄 Work Description
- ScheduleItem 컴포넌트가 Schedule 타입에 직접 의존하지 않도록 props를 분해하여 전달받는 구조로 리팩토링
- ScheduleList에서 ScheduleItem으로 전달하는 방식 변경
- 메인 페이지에서 사용하던 더미 스케줄 데이터를 mock 파일로 분리 (`mockSchedule.ts`)

<br><br>

## 📷 Screenshot
<!-- 필요 시 컴포넌트 전/후 비교 이미지 또는 구조 변화 다이어그램 첨부 -->

<br><br>

## 💬 To Reviewers


<br><br>

## 🔗 Reference
