### PR TITLE
style/#39: 하단 네비게이션 바 크기 조절

### DIFF
--- a/src/components/global/MainNavigationBar.tsx
+++ b/src/components/global/MainNavigationBar.tsx
@@ -4,12 +4,12 @@ import Archive from '@/assets/nav-icons/archive.svg?react';
 import Community from '@/assets/nav-icons/community.svg?react';
 import Settings from '@/assets/nav-icons/settings.svg?react';
 
-const NavigationBar = () => {
+const MainNavigationBar = () => {
   const location = useLocation();
   const currentPath = location.pathname;
 
   const getLinkClass = (path: string) =>
-    `w-[150px] h-[90px] flex items-center justify-center ${
+    `w-[150px] sm:h-[60px] h-[45px] flex items-center justify-center ${
       currentPath === path ? 'bg-white' : ''
     }`;
 
@@ -17,21 +17,29 @@ const NavigationBar = () => {
     currentPath === path ? 'text-primary' : 'text-[#918F9D]';
 
   return (
-    <div className='w-full max-w-full flex flex-row items-center bg-black'>
+    <div className='w-full max-w-full sm:h-[60px] h-[45px] flex flex-row items-center bg-black'>
       <Link to='/' className={getLinkClass('/')}>
-        <Home className={getIconClass('/')} />
+        <Home
+          className={`${getIconClass('/')} w-[18px] h-[18px] sm:w-[25px] sm:h-[25px]`}
+        />
       </Link>
       <Link to='/archive' className={getLinkClass('/archive')}>
-        <Archive className={getIconClass('/archive')} />
+        <Archive
+          className={`${getIconClass('/archive')} w-[18px] h-[18px] sm:w-[25px] sm:h-[25px]`}
+        />
       </Link>
       <Link to='/community' className={getLinkClass('/community')}>
-        <Community className={getIconClass('/community')} />
+        <Community
+          className={`${getIconClass('/community')} w-[18px] h-[18px] sm:w-[25px] sm:h-[25px]`}
+        />
       </Link>
       <Link to='/settings' className={getLinkClass('/settings')}>
-        <Settings className={getIconClass('/settings')} />
+        <Settings
+          className={`${getIconClass('/settings')} w-[18px] h-[18px] sm:w-[25px] sm:h-[25px]`}
+        />
       </Link>
     </div>
   );
 };
 
-export default NavigationBar;
+export default MainNavigationBar;

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,15 +1,15 @@
-import NavigationBar from '@/components/NavigationBar';
+import MainNavigationBar from '@/components/global/MainNavigationBar';
 import {Outlet} from 'react-router-dom';
 
 const MainLayout = () => {
   return (
     <div className='w-full min-h-screen flex justify-center overflow-x-hidden'>
-      <div className='w-full max-w-[600px] pb-[90px]'>
+      <div className='w-full max-w-[600px] sm:pb-60 pb-44'>
         <Outlet />
       </div>
 
       <footer className='w-full max-w-[600px] fixed bottom-0 left-1/2 -translate-x-1/2'>
-        <NavigationBar />
+        <MainNavigationBar />
       </footer>
     </div>
   );


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
close #39 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
하단 네비게이션 바, 아이콘 크기 수정했습니다
기존 컴포넌트명 NavigationBar -> MainNavigationBar로 변경하고, global 폴더에 추가해 뒀습니다

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="443" height="707" alt="image" src="https://github.com/user-attachments/assets/57f02367-a208-4a5f-bfef-2a01a2d2109a" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
디자인 팀에서 웹사이트에서도 모바일 픽셀에 맞추면 너무 작을 것 같다는 의견이 있어서, 반응형으로 조절했습니다! (모바일 -> 45px, 웹 -> 60px) 

<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->