### PR TITLE
feat/#85: 커뮤니티 카테고리별 에디터 로직 연결 

### DIFF
--- a/src/components/community/common/CommunityCategory.tsx
+++ b/src/components/community/common/CommunityCategory.tsx
@@ -5,12 +5,18 @@
 interface CommunityCategoryProps {
   category: string;
   isSelected?: boolean;
+  onClick?: () => void;
 }
 
-const CommunityCategory = ({category, isSelected}: CommunityCategoryProps) => {
+const CommunityCategory = ({
+  category,
+  isSelected,
+  onClick,
+}: CommunityCategoryProps) => {
   return (
     <div
-      className={`flex w-[93px] h-[36px] justify-center items-center rounded-[10px] border-[1px] border-[#7B4CFA] font-semibold bg-[#fff] ${isSelected ? 'bg-primary text-white' : ''}`}>
+      onClick={onClick}
+      className={`flex w-[93px] h-[36px] justify-center items-center rounded-[10px] border-[1px] cursor-pointer border-[#7B4CFA] font-semibold bg-[#fff] ${isSelected ? 'bg-primary text-white' : ''}`}>
       {category}
     </div>
   );

--- a/src/components/community/content/ContentEditor.tsx
+++ b/src/components/community/content/ContentEditor.tsx
@@ -5,7 +5,7 @@ import TextAlign from '@tiptap/extension-text-align';
 import {Color, FontSize, TextStyle} from '@tiptap/extension-text-style';
 import Highlight from '@tiptap/extension-highlight';
 import PlaceHolder from '@tiptap/extension-placeholder';
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {CustomLink} from './lib/CustomLink';
 
 interface ContentEditorProps {
@@ -77,6 +77,12 @@ const ContentEditor = ({defaultContent}: ContentEditorProps) => {
       },
     },
   });
+
+  useEffect(() => {
+    if (bodyEditor && defaultContent !== bodyEditor.getHTML()) {
+      bodyEditor.commands.setContent(defaultContent);
+    }
+  }, [defaultContent, bodyEditor]);
   return (
     <div className='flex flex-col'>
       <EditorContent

--- a/src/components/community/content/EditorMenuBar.tsx
+++ b/src/components/community/content/EditorMenuBar.tsx
@@ -27,9 +27,9 @@ const EditorMenuBar = ({editor, onImageUpload}: EditorMenuBarProps) => {
   });
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [hasLink, setHasLink] = useState(false);
+  const [hasLink, setHasLink] = useState<boolean>(false);
 
-  const [showFontSizePicker, setShowFontSizePicker] = useState(false);
+  const [showFontSizePicker, setShowFontSizePicker] = useState<boolean>(false);
   const fontSizePickerRef = useRef<HTMLDivElement>(null);
 
   const baseButtonClass =
@@ -39,6 +39,7 @@ const EditorMenuBar = ({editor, onImageUpload}: EditorMenuBarProps) => {
     ref: fontSizePickerRef,
     onClickOutside: () => setShowFontSizePicker(false),
   });
+
   useEffect(() => {
     if (!editor) return;
 
@@ -110,22 +111,22 @@ const EditorMenuBar = ({editor, onImageUpload}: EditorMenuBarProps) => {
       />
       <button
         onClick={() => editor.chain().focus().toggleBold().run()}
-        className={`${activeMarks.bold ? 'bg-gray-1 rounded-[5px]' : ''} ${baseButtonClass}`}>
+        className={`${activeMarks.bold ? 'bg-gray-200/50 rounded-[5px]' : ''} ${baseButtonClass}`}>
         <BoldIcon className='w-25 h-25 sm:w-30 sm:h-30' />
       </button>
       <button
         onClick={() => editor.chain().focus().toggleUnderline().run()}
-        className={`${activeMarks.underline ? 'bg-gray-1 rounded-[5px]' : ''} ${baseButtonClass}`}>
+        className={`${activeMarks.underline ? 'bg-gray-200/50 rounded-[5px]' : ''} ${baseButtonClass}`}>
         <UnderlineIcon className='w-25 h-25 sm:w-30 sm:h-30' />
       </button>
       <button
         onClick={() => editor.chain().focus().toggleItalic().run()}
-        className={`${activeMarks.italic ? 'bg-gray-1 rounded-[5px]' : ''} ${baseButtonClass}`}>
+        className={`${activeMarks.italic ? 'bg-gray-200/50 rounded-[5px]' : ''} ${baseButtonClass}`}>
         <ItalicIcon className='w-25 h-25 sm:w-30 sm:h-30' />
       </button>
       <button
         onClick={() => editor.chain().focus().toggleStrike().run()}
-        className={`${activeMarks.strike ? 'bg-gray-1 rounded-[5px]' : ''} ${baseButtonClass}`}>
+        className={`${activeMarks.strike ? 'bg-gray-200/50 rounded-[5px]' : ''} ${baseButtonClass}`}>
         <CrossIcon className='w-17 h-17 sm:w-22 sm:h-22' />
       </button>
 
@@ -133,7 +134,9 @@ const EditorMenuBar = ({editor, onImageUpload}: EditorMenuBarProps) => {
       <button
         onClick={() => editor.chain().focus().setTextAlign('left').run()}
         className={`${
-          editor.isActive({textAlign: 'left'}) ? 'bg-gray-1 rounded-[5px]' : ''
+          editor.isActive({textAlign: 'left'})
+            ? 'bg-gray-200/50 rounded-[5px]'
+            : ''
         } ${baseButtonClass}`}>
         <TextLeftIcon className='w-25 h-25 sm:w-30 sm:h-30' />
       </button>
@@ -141,7 +144,7 @@ const EditorMenuBar = ({editor, onImageUpload}: EditorMenuBarProps) => {
         onClick={() => editor.chain().focus().setTextAlign('center').run()}
         className={`${
           editor.isActive({textAlign: 'center'})
-            ? 'bg-gray-1 rounded-[5px]'
+            ? 'bg-gray-200/50 rounded-[5px]'
             : ''
         } ${baseButtonClass}`}>
         <TextCenterIcon className='w-25 h-25 sm:w-30 sm:h-30' />
@@ -149,14 +152,16 @@ const EditorMenuBar = ({editor, onImageUpload}: EditorMenuBarProps) => {
       <button
         onClick={() => editor.chain().focus().setTextAlign('right').run()}
         className={`${
-          editor.isActive({textAlign: 'right'}) ? 'bg-gray-1 rounded-[5px]' : ''
+          editor.isActive({textAlign: 'right'})
+            ? 'bg-gray-200/50 rounded-[5px]'
+            : ''
         } ${baseButtonClass}`}>
         <TextRightIcon className='w-25 h-25 sm:w-30 sm:h-30' />
       </button>
       {/* 링크 */}
       <button
         onClick={addLink}
-        className={`${hasLink ? 'bg-gray-1 rounded-[5px]' : ''} ${baseButtonClass}`}>
+        className={`${hasLink ? 'bg-gray-200/50 rounded-[5px]' : ''} ${baseButtonClass}`}>
         <LinkIcon className='w-25 h-25 sm:w-30 sm:h-30' />
       </button>
       {/* 폰트 사이즈 선택기 */}
@@ -167,14 +172,22 @@ const EditorMenuBar = ({editor, onImageUpload}: EditorMenuBarProps) => {
             ['12px', '16px', '20px', '24px'].some((size) =>
               editor?.isActive('textStyle', {fontSize: size})
             )
-              ? 'bg-gray-1 rounded-[5px]'
+              ? 'bg-gray-200/50 rounded-[5px]'
               : ''
           }`}>
           <TextSizeIcon className='w-25 h-25 sm:w-30 sm:h-30' />
         </button>
 
         {showFontSizePicker && (
-          <div className='absolute top-full left-0 z-20 mt- h-[210px] overflow-y-auto bg-white p-2 rounded shadow-lg w-[70px] text-sm'>
+          <div
+            style={{
+              overflowY: 'scroll',
+              scrollbarWidth: 'thin',
+            }}
+            className='absolute top-full left-0 z-20 mt-1 h-[210px] bg-white p-2 rounded shadow-lg w-[70px] text-sm'>
+            <div className='w-full px-3 py-3 text-center text-gray-400 cursor-default select-none text-[12px]'>
+              글자 크기
+            </div>
             {[
               '11px',
               '13px',
@@ -190,7 +203,7 @@ const EditorMenuBar = ({editor, onImageUpload}: EditorMenuBarProps) => {
               <button
                 key={size}
                 onClick={() => changeFontSize(size)}
-                className='w-full px-3 py-3 text-center hover:bg-gray-1 rounded'>
+                className='w-full px-3 py-3 text-center hover:bg-gray-200/50 hover:font-semibold rounded'>
                 {size}
               </button>
             ))}

--- a/src/components/community/post/FilteredPostList.tsx
+++ b/src/components/community/post/FilteredPostList.tsx
@@ -5,8 +5,10 @@ import {useNavigate, useParams} from 'react-router-dom';
 import PostListItem from './PostListItem';
 import {mockPosts} from '@/mocks/mockPosts';
 import {useMemo} from 'react';
-import {CATEGORY_MAP} from '@/types/categoryMap';
-import type {CategoryKey, CategoryLabel} from '@/types/categoryMap';
+import {
+  getCategoryNameFromUrl,
+  getUrlFromCategoryName,
+} from '@/util/categoryMapper';
 import useCommunityNavigation from '@/hooks/useCommunityNavigation';
 
 const FilteredPostList = () => {
@@ -14,12 +16,7 @@ const FilteredPostList = () => {
   const navigate = useNavigate();
   const {goToPostDetail} = useCommunityNavigation();
 
-  const categoryLabel: CategoryLabel | null = useMemo(() => {
-    if (category && category in CATEGORY_MAP) {
-      return CATEGORY_MAP[category as CategoryKey];
-    }
-    return null;
-  }, [category]);
+  const categoryLabel = category ? getCategoryNameFromUrl(category) : null;
 
   const filteredPosts = useMemo(() => {
     return categoryLabel
@@ -52,7 +49,11 @@ const FilteredPostList = () => {
         {/* 오른쪽: 게시글 작성 버튼 */}
         <button
           className='flex items-center gap-[8px] cursor-pointer'
-          onClick={() => navigate(`/community/${category}/write`)}>
+          onClick={() =>
+            navigate(
+              `/community/${getUrlFromCategoryName(categoryLabel)}/write`
+            )
+          }>
           <div className='w-[19px] h-[19px]'>
             <WritePost className='w-full h-full' />
           </div>
@@ -63,7 +64,8 @@ const FilteredPostList = () => {
       {/* 게시글 리스트 */}
       <div className='flex flex-col mt-[22px] gap-[19px]'>
         {filteredPosts.map((post) => {
-          const handleClick = () => goToPostDetail(category as string, post.id);
+          const handleClick = () =>
+            goToPostDetail(getUrlFromCategoryName(categoryLabel), post.id);
           return (
             <PostListItem key={post.id} post={post} onClick={handleClick} />
           );

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -4,15 +4,37 @@ import {useState} from 'react';
 import {ShareTemplate} from '@/constant';
 import ShareBadgeSection from '@/components/community/content/ShareBadgeSection';
 import EditorToggleSection from '@/components/community/content/EditorToggleSection';
+import {useNavigate, useParams} from 'react-router-dom';
+
+const categoryMap: Record<string, string> = {
+  daily: '일상',
+  share: '나눔 · 거래',
+  tip: '꿀팁',
+} as const;
+
+const reverseCategoryMap = {
+  일상: 'daily',
+  '나눔 · 거래': 'share',
+  꿀팁: 'tip',
+} as const;
+
+type CategoryName = keyof typeof reverseCategoryMap;
 
 const CommunityEditPage = () => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const selectedCategory = '나눔 · 거래'; // 임시 설정
+  const navigate = useNavigate();
+  const {category} = useParams();
+  const selectedCategory = categoryMap[category ?? ''] ?? '일상';
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
   const [clickedPlayBadge, setClickedPlayBadge] = useState<string | null>(null);
   const [clickedCategoryBadge, setClickedCategoryBadge] = useState<
     string | null
   >(null);
 
+  const handleCategoryClick = (categoryName: CategoryName) => {
+    const key = reverseCategoryMap[categoryName];
+    if (key) navigate(`/community/${key}/write`);
+  };
   const togglePlayBadge = (text: string) => {
     setClickedPlayBadge((prev) => (prev === text ? null : text));
   };
@@ -30,13 +52,16 @@ const CommunityEditPage = () => {
     <div className='w-full flex flex-col'>
       <div className='flex flex-row justify-between items-center px-20 py-12'>
         <div className='flex flex-row gap-10'>
-          {['일상', '나눔 · 거래', '꿀팁'].map((category) => (
-            <CommunityCategory
-              key={category}
-              category={category}
-              isSelected={selectedCategory === category}
-            />
-          ))}
+          {(Object.values(categoryMap) as CategoryName[]).map(
+            (categoryName) => (
+              <CommunityCategory
+                key={categoryName}
+                category={categoryName}
+                isSelected={selectedCategory === categoryName}
+                onClick={() => handleCategoryClick(categoryName)}
+              />
+            )
+          )}
         </div>
       </div>
 

--- a/src/pages/community/CommunityEditPage.tsx
+++ b/src/pages/community/CommunityEditPage.tsx
@@ -5,25 +5,17 @@ import {ShareTemplate} from '@/constant';
 import ShareBadgeSection from '@/components/community/content/ShareBadgeSection';
 import EditorToggleSection from '@/components/community/content/EditorToggleSection';
 import {useNavigate, useParams} from 'react-router-dom';
-
-const categoryMap: Record<string, string> = {
-  daily: '일상',
-  share: '나눔 · 거래',
-  tip: '꿀팁',
-} as const;
-
-const reverseCategoryMap = {
-  일상: 'daily',
-  '나눔 · 거래': 'share',
-  꿀팁: 'tip',
-} as const;
-
-type CategoryName = keyof typeof reverseCategoryMap;
+import {
+  categoryList,
+  getCategoryNameFromUrl,
+  getUrlFromCategoryName,
+} from '@/util/categoryMapper';
 
 const CommunityEditPage = () => {
   const navigate = useNavigate();
   const {category} = useParams();
-  const selectedCategory = categoryMap[category ?? ''] ?? '일상';
+  const rawCategory = getCategoryNameFromUrl(category ?? '');
+  const selectedCategory = rawCategory === 'HOT' ? '일상' : rawCategory;
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const [clickedPlayBadge, setClickedPlayBadge] = useState<string | null>(null);
@@ -31,9 +23,9 @@ const CommunityEditPage = () => {
     string | null
   >(null);
 
-  const handleCategoryClick = (categoryName: CategoryName) => {
-    const key = reverseCategoryMap[categoryName];
-    if (key) navigate(`/community/${key}/write`);
+  const handleCategoryClick = (categoryName: string) => {
+    const urlSlug = getUrlFromCategoryName(categoryName);
+    navigate(`/community/${urlSlug}/write`);
   };
   const togglePlayBadge = (text: string) => {
     setClickedPlayBadge((prev) => (prev === text ? null : text));
@@ -52,16 +44,16 @@ const CommunityEditPage = () => {
     <div className='w-full flex flex-col'>
       <div className='flex flex-row justify-between items-center px-20 py-12'>
         <div className='flex flex-row gap-10'>
-          {(Object.values(categoryMap) as CategoryName[]).map(
-            (categoryName) => (
+          {categoryList
+            .filter((categoryName) => categoryName !== 'HOT')
+            .map((categoryName) => (
               <CommunityCategory
                 key={categoryName}
                 category={categoryName}
                 isSelected={selectedCategory === categoryName}
                 onClick={() => handleCategoryClick(categoryName)}
               />
-            )
-          )}
+            ))}
         </div>
       </div>
 

--- a/src/types/categoryMap.ts
+++ b/src/types/categoryMap.ts
@@ -1,9 +1,0 @@
-export const CATEGORY_MAP = {
-  tip: '꿀팁',
-  daily: '일상',
-  share: '나눔 · 거래',
-  hot: 'HOT',
-} as const;
-
-export type CategoryKey = keyof typeof CATEGORY_MAP; // 'tip' | 'daily' | ...
-export type CategoryLabel = (typeof CATEGORY_MAP)[CategoryKey]; // '꿀팁' | '일상' | ...

--- a/src/util/categoryMapper.ts
+++ b/src/util/categoryMapper.ts
@@ -1,0 +1,22 @@
+export const categoryMap: Record<string, string> = {
+  daily: '일상',
+  share: '나눔 · 거래',
+  tip: '꿀팁',
+  hot: 'HOT',
+} as const;
+
+export const reverseCategoryMap: Record<string, keyof typeof categoryMap> = {
+  일상: 'daily',
+  '나눔 · 거래': 'share',
+  꿀팁: 'tip',
+  HOT: 'hot',
+};
+
+export const getCategoryNameFromUrl = (slug: string): string => {
+  return categoryMap[slug] ?? '일상';
+};
+
+export const getUrlFromCategoryName = (name: string): string => {
+  return reverseCategoryMap[name] ?? 'daily';
+};
+export const categoryList = Object.values(categoryMap);


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
close #85 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
* 커뮤니티 메인 페이지 -> 게시글 리스트 -> 게시글 작성하기 관련 카테고리별 에디터 로직을 연결했습니다. 
  * 일상 에디터 경로 -> `community/daily/write`
  * 꿀팁 에디터 경로 -> `community/tip/write`
  * 나눔 거래 에디터 경로 -> `community/share/write`
  * 핫 게시물에서 게시글 작성하기 진입 시 기본 설정 카테고리는 일상으로 해뒀습니다.
* 게시글 에디터에서 카테고리 선택 시 해당 카테고리 버전 에디터로 자동 이동 가능하게 구현해 뒀습니다.

* 게시글 에디터 -> 폰트 크기 에디터에 스크롤바가 추가되었습니다.
* 게시글 에디터 selected된 스타일 배경색을 수정했습니다. 
<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![Animation](https://github.com/user-attachments/assets/200f265a-b57c-4f1a-84e5-902373bf59e7)


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
나눔 거래 게시글 리스트 UI에서 <게시글 작성> 부분에 에디터 경로 연결만 해 두면 될 것 같습니다


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->