### PR TITLE
feat/#99 메인 페이지(홈) 온보딩 모달 1회 표시

### DIFF
--- a/src/components/modal/OnboardingModal/OnboardingWrapper.tsx
+++ b/src/components/modal/OnboardingModal/OnboardingWrapper.tsx
@@ -65,16 +65,18 @@ export default function OnboardingWrapper({onDone}: {onDone: () => void}) {
   };
 
   return (
-    <div className='absolute inset-0 z-50 flex items-start justify-center pt-[64px] bg-black/50'>
-      <OnboardingModal
-        message={message}
-        imageSrc={imageSrc}
-        showPrev={step > 0}
-        showNext={!isLast}
-        isLastStep={isLast}
-        onPrev={() => setStep((prev) => prev - 1)}
-        onNext={handleNext}
-      />
+    <div className='fixed inset-0 z-[9999] flex justify-center'>
+      <div className='w-full max-w-[600px] h-full bg-black/50 flex items-center justify-center'>
+        <OnboardingModal
+          message={message}
+          imageSrc={imageSrc}
+          showPrev={step > 0}
+          showNext={!isLast}
+          isLastStep={isLast}
+          onPrev={() => setStep((prev) => prev - 1)}
+          onNext={handleNext}
+        />
+      </div>
     </div>
   );
 }

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -10,8 +10,15 @@ import {useAuthStore} from '@/stores/authStore';
 export default function MainPage() {
   /** mock user data */
   const {user, isAuthenticated} = useAuthStore();
-  const [isOnboardingDone, setIsOnboardingDone] = useState(false);
+  const [isOnboardingDone, setIsOnboardingDone] = useState(
+    localStorage.getItem('isOnboardingDone') === 'true'
+  );
   const [schedules, setSchedules] = useState<Schedule[]>(mockSchedules);
+
+  const handleOnboardingDone = () => {
+    setIsOnboardingDone(true);
+    localStorage.setItem('isOnboardingDone', 'true');
+  };
 
   const handleLikeClick = (clicked: Schedule) => {
     setSchedules((prev) =>
@@ -22,9 +29,9 @@ export default function MainPage() {
   };
 
   return (
-    <div className='relative'>
+    <div className='relative min-h-screen'>
       {!isAuthenticated && !isOnboardingDone && (
-        <OnboardingWrapper onDone={() => setIsOnboardingDone(true)} />
+        <OnboardingWrapper onDone={handleOnboardingDone} />
       )}
       <div className='bg-black flex flex-col items-center'>
         <MainHeader isLoggedIn={isAuthenticated} username={user?.name} />


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#99 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
1. 컴포넌트 첫 렌더 때 **localStorage**에서 `isOnboardingDone`을 읽어 상태 초기화
2. 비로그인이고 값이 **false**이면 `OnboardingWrapper`를 렌더
3. 모달에서 완료 시 `handleOnboardingDone` 실행 → 상태 **true**로 전환, localStorage에 **true** 저장
4. 이후 동일 브라우저에선 다시 안 뜸 저장소 초기화(캐시 지우기, 시크릿 탭, 다른 브라우저/기기)하면 다시 뜸

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![화면 기록 2025-08-12 오후 4 11 32](https://github.com/user-attachments/assets/7491a404-4eba-4aa4-9944-742f2b1a61f5)


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->