### PR TITLE
feat/#110 useScrollToTop 전역 적용으로 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,8 +47,11 @@ import WrittenCommentPage from './pages/WrittenCommentPage';
 import BlockedUserPage from './pages/BlockedUserPage';
 import ChangePassword from './pages/setting/ChangePassword';
 import NotificationPage from './pages/NotificationPage';
+import useScrollToTop from './hooks/useScrollToTop';
 
 function App() {
+  useScrollToTop();
+
   const {isAuthenticated, isLoading} = useAuthStore();
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,9 +49,12 @@ import ChangePassword from './pages/setting/ChangePassword';
 import NotificationPage from './pages/NotificationPage';
 import useScrollToTop from './hooks/useScrollToTop';
 
-function App() {
+const ScrollManager = () => {
   useScrollToTop();
+  return null;
+};
 
+function App() {
   const {isAuthenticated, isLoading} = useAuthStore();
 
   useEffect(() => {
@@ -63,6 +66,7 @@ function App() {
 
   return (
     <BrowserRouter>
+      <ScrollManager />
       <Routes>
         {/* NavigationBar가 필요한 페이지 */}
         <Route element={<MainLayout />}>

--- a/src/components/main/PerformanceCardList.tsx
+++ b/src/components/main/PerformanceCardList.tsx
@@ -4,7 +4,6 @@ import PerformanceCard from '@/components/main/PerformanceCard';
 import {usePerformanceStore} from '@/stores/usePerformanceStore';
 import '@/styles/skeleton.css';
 import type {Performance} from '@/types/performance';
-import useScrollToTop from '@/hooks/useScrollToTop';
 
 const ITEMS_PER_PAGE = 9;
 
@@ -32,7 +31,12 @@ const PerformanceCardList = ({
     fetchPerformances();
   }, [fetchPerformances]);
 
-  useScrollToTop(currentPage); // 페이지 바뀔 때마다 스크롤 위로
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, [currentPage]);
 
   // todo: 로딩 표시, 공연 없음 예외 처리
   // 임시로 스켈레톤 표시

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,8 +1,15 @@
 import {useEffect} from 'react';
-const useScrollToTop = (trigger: unknown) => {
+import {useLocation} from 'react-router-dom';
+
+const useScrollToTop = (behavior: 'auto' | 'smooth' = 'auto') => {
+  const {pathname} = useLocation();
+
   useEffect(() => {
-    window.scrollTo({top: 0, behavior: 'smooth'});
-  }, [trigger]);
+    window.scrollTo({
+      top: 0,
+      behavior,
+    });
+  }, [pathname, behavior]);
 };
 
 export default useScrollToTop;

--- a/src/pages/BlockedUserPage.tsx
+++ b/src/pages/BlockedUserPage.tsx
@@ -1,7 +1,7 @@
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
 import BlockedUser from '@/components/setting/BlockedUser';
 import {mockList} from '@/mocks/mockBlockedUsers';
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import Pagination from 'react-js-pagination';
 const ITEMS_PER_PAGE = 10;
 
@@ -12,6 +12,14 @@ const BlockedUserPage = () => {
   const indexOfLastItem = currentPage * ITEMS_PER_PAGE;
   const indexOfFirstItem = indexOfLastItem - ITEMS_PER_PAGE;
   const currentItems = blockedUserList.slice(indexOfFirstItem, indexOfLastItem);
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, [currentPage]);
+
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };

--- a/src/pages/BlockedUserPage.tsx
+++ b/src/pages/BlockedUserPage.tsx
@@ -1,7 +1,7 @@
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
 import BlockedUser from '@/components/setting/BlockedUser';
 import {mockList} from '@/mocks/mockBlockedUsers';
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import Pagination from 'react-js-pagination';
 const ITEMS_PER_PAGE = 10;
 
@@ -15,10 +15,6 @@ const BlockedUserPage = () => {
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };
-
-  useEffect(() => {
-    window.scrollTo({top: 0, behavior: 'smooth'});
-  }, []);
 
   return (
     <div className='flex flex-col gap-40'>

--- a/src/pages/ScrappedMagazinePage.tsx
+++ b/src/pages/ScrappedMagazinePage.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import Pagination from 'react-js-pagination';
 import {mockMagazine} from '@/mocks/mockMagazine';
 import PostCardItem from '@/components/community/post/PostCardItem';
@@ -11,9 +11,6 @@ const ScrappedMagazinePage = () => {
     (magazine) => magazine.isBookmarked
   );
 
-  useEffect(() => {
-    window.scrollTo({top: 0, behavior: 'smooth'});
-  }, []);
   const [currentPage, setCurrentPage] = useState(1);
   const totalItemsCount = scrappedMagazine.length;
 

--- a/src/pages/ScrappedMagazinePage.tsx
+++ b/src/pages/ScrappedMagazinePage.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import Pagination from 'react-js-pagination';
 import {mockMagazine} from '@/mocks/mockMagazine';
 import PostCardItem from '@/components/community/post/PostCardItem';
@@ -20,6 +20,13 @@ const ScrappedMagazinePage = () => {
     indexOfFirstItem,
     indexOfLastItem
   );
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, [currentPage]);
 
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);

--- a/src/pages/ScrappedPostPage.tsx
+++ b/src/pages/ScrappedPostPage.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import Pagination from 'react-js-pagination';
 import {mockPosts} from '@/mocks/mockPosts';
 import PostListItem from '@/components/community/post/PostListItem';
@@ -12,6 +12,14 @@ const ScrappedPostPage = () => {
   const indexOfLastItem = currentPage * ITEMS_PER_PAGE;
   const indexOfFirstItem = indexOfLastItem - ITEMS_PER_PAGE;
   const currentItems = scrappedPost.slice(indexOfFirstItem, indexOfLastItem);
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, [currentPage]);
+
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };

--- a/src/pages/ScrappedPostPage.tsx
+++ b/src/pages/ScrappedPostPage.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import Pagination from 'react-js-pagination';
 import {mockPosts} from '@/mocks/mockPosts';
 import PostListItem from '@/components/community/post/PostListItem';
@@ -15,9 +15,7 @@ const ScrappedPostPage = () => {
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };
-  useEffect(() => {
-    window.scrollTo({top: 0, behavior: 'smooth'});
-  }, []);
+
   return (
     <div className='flex flex-col gap-40'>
       {/* 상단 */}

--- a/src/pages/WrittenCommentPage.tsx
+++ b/src/pages/WrittenCommentPage.tsx
@@ -1,7 +1,7 @@
 import PostListItem from '@/components/community/post/PostListItem';
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
 import {mockPosts} from '@/mocks/mockPosts';
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import Pagination from 'react-js-pagination';
 const ITEMS_PER_PAGE = 9;
 
@@ -12,6 +12,14 @@ const WrittenCommentPage = () => {
   const indexOfLastItem = currentPage * ITEMS_PER_PAGE;
   const indexOfFirstItem = indexOfLastItem - ITEMS_PER_PAGE;
   const currentItems = scrappedPost.slice(indexOfFirstItem, indexOfLastItem);
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, [currentPage]);
+
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };

--- a/src/pages/WrittenCommentPage.tsx
+++ b/src/pages/WrittenCommentPage.tsx
@@ -1,7 +1,7 @@
 import PostListItem from '@/components/community/post/PostListItem';
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
 import {mockPosts} from '@/mocks/mockPosts';
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import Pagination from 'react-js-pagination';
 const ITEMS_PER_PAGE = 9;
 
@@ -15,10 +15,6 @@ const WrittenCommentPage = () => {
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };
-
-  useEffect(() => {
-    window.scrollTo({top: 0, behavior: 'smooth'});
-  }, []);
 
   return (
     <div className='flex flex-col gap-40'>

--- a/src/pages/WrittenPostPage.tsx
+++ b/src/pages/WrittenPostPage.tsx
@@ -1,7 +1,7 @@
 import PostListItem from '@/components/community/post/PostListItem';
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
 import {mockPosts} from '@/mocks/mockPosts';
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import Pagination from 'react-js-pagination';
 const ITEMS_PER_PAGE = 9;
 
@@ -12,6 +12,14 @@ const WrittenPostPage = () => {
   const indexOfLastItem = currentPage * ITEMS_PER_PAGE;
   const indexOfFirstItem = indexOfLastItem - ITEMS_PER_PAGE;
   const currentItems = scrappedPost.slice(indexOfFirstItem, indexOfLastItem);
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, [currentPage]);
+
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };

--- a/src/pages/WrittenPostPage.tsx
+++ b/src/pages/WrittenPostPage.tsx
@@ -1,7 +1,7 @@
 import PostListItem from '@/components/community/post/PostListItem';
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
 import {mockPosts} from '@/mocks/mockPosts';
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import Pagination from 'react-js-pagination';
 const ITEMS_PER_PAGE = 9;
 
@@ -15,10 +15,6 @@ const WrittenPostPage = () => {
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };
-
-  useEffect(() => {
-    window.scrollTo({top: 0, behavior: 'smooth'});
-  }, []);
 
   return (
     <div className='flex flex-col gap-40'>

--- a/src/pages/community/SharePostsPage.tsx
+++ b/src/pages/community/SharePostsPage.tsx
@@ -1,10 +1,9 @@
-import {useMemo, useState} from 'react';
+import {useMemo, useState, useEffect} from 'react';
 import Pagination from 'react-js-pagination';
 import {mockSharePosts} from '@/mocks/mockSharePosts';
 import {useNavigate} from 'react-router-dom';
 import PostCardItem from '@/components/community/post/PostCardItem';
 import CommunityListHeader from '@/components/community/common/CommunityListHeader';
-import useScrollToTop from '@/hooks/useScrollToTop';
 
 const ITEMS_PER_PAGE = 6;
 
@@ -12,7 +11,13 @@ const SharePostsPage = () => {
   const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState(1);
 
-  useScrollToTop(currentPage);
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, [currentPage]);
+
   const totalItemsCount = mockSharePosts.length;
 
   const currentItems = useMemo(() => {


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
closed #110

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
1. 전역 `useScrollToTop` 훅 구현 및 적용
- 라우트 변경 시 스크롤을 맨 위로 이동하도록 `App.tsx`에 훅을 적용하여 모든 페이지 전환 시 **auto** 스크롤이 되도록 설정했습니다.

2. 페이지네이션 컴포넌트 스크롤 로직 개선
- `SharePostsPage`, `PerformanceCardList`, `BlockedUserPage` 등 페이지네이션을 사용하는 컴포넌트들에 페이지 번호(currentPage)가 변경될 때만 **smooth** 스크롤이 적용되도록 `useEffect`를 추가했습니다.

3. 기존에 중복되거나 불필요한 스크롤 로직들을 제거했습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->