### PR TITLE
feat/#114: 세팅(마이페이지) 문의하기 api 연동

### DIFF
--- a/src/api/mypageApi.ts
+++ b/src/api/mypageApi.ts
@@ -3,6 +3,7 @@
 import getErrorMessage from '@/util/getErrorMessage';
 import {privateAxios} from './axios';
 import {ENDPOINT} from './urls';
+import type {EnquiryType} from '@/types/enquiry';
 
 export const getMypageInfo = async () => {
   try {
@@ -107,12 +108,29 @@ export const getPolicyTerms = async () => {
 
 export const putProfileImage = async (formData: FormData) => {
   try {
-    const response = await privateAxios.put(ENDPOINT.MYPAGE_PROFILE_IMAGE, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    const response = await privateAxios.put(
+      ENDPOINT.MYPAGE_PROFILE_IMAGE,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }
+    );
     return response.data.data;
+  } catch (error: any) {
+    // const status = error.response.data.status;
+    const code = error.response.data.code;
+    const errorMessage = getErrorMessage(code);
+    console.error('An unexpected error occurred:', error);
+    throw new Error(errorMessage);
+  }
+};
+
+export const postInquiries = async (data: EnquiryType) => {
+  try {
+    const response = await privateAxios.post(ENDPOINT.MYPAGE_INQUIRIES, data);
+    return response.data;
   } catch (error: any) {
     // const status = error.response.data.status;
     const code = error.response.data.code;

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -30,6 +30,7 @@ export const ENDPOINT = {
   MYPAGE_PRIVACY: 'api/v1/mypage/policy/privacy',
   MYPAGE_TERMS: 'api/v1/mypage/policy/terms',
   MYPAGE_PROFILE_IMAGE: 'api/v1/mypage/profile-image',
+  MYPAGE_INQUIRIES: 'api/v1/mypage/inquiries',
 
   //performance
   PERFORMANCE: '/api/v1/performance',

--- a/src/constants/enquiry.ts
+++ b/src/constants/enquiry.ts
@@ -16,7 +16,7 @@ export const enquiryCategories = [
     category: '제휴 및 광고 문의',
   },
   {
-    id: 'OTHER(기타)',
+    id: 'OTHER',
     category: '기타',
   },
 ];

--- a/src/constants/enquiry.ts
+++ b/src/constants/enquiry.ts
@@ -1,26 +1,22 @@
 export const enquiryCategories = [
   {
-    id: 0,
+    id: 'PERFORMANCE_INFO_UPDATE',
     category: '공연 정보 수정 요청',
   },
   {
-    id: 1,
+    id: 'COMMUNITY_USAGE',
     category: '커뮤니티 이용 관련(게시글/댓글/채팅)',
   },
   {
-    id: 2,
-    category: '신고 및 차단 요청',
-  },
-  {
-    id: 3,
+    id: 'ACCOUNT_LOGIN',
     category: '계정/로그인 문제',
   },
   {
-    id: 4,
+    id: 'PARTNERSHIP_AD',
     category: '제휴 및 광고 문의',
   },
   {
-    id: 5,
+    id: 'OTHER(기타)',
     category: '기타',
   },
 ];

--- a/src/pages/setting/EnquirePage.tsx
+++ b/src/pages/setting/EnquirePage.tsx
@@ -3,26 +3,40 @@ import ChevronRight from '@/assets/arrows/chevron-right.svg?react';
 import {enquiryCategories} from '@/constants/enquiry';
 import {useRef, useState} from 'react';
 import useClickOutside from '@/hooks/useClickOutside';
+import {useMutation} from '@tanstack/react-query';
+import {postInquiries} from '@/api/mypageApi';
+import LoadingOverlay from '@/components/global/LoadingOverlay';
+import Modal from '@/components/global/Modal';
+import {useNavigate} from 'react-router-dom';
+import type {EnquiryCategoryType} from '@/types/enquiry';
 
 const EnquirePage = () => {
+  const navigate = useNavigate();
   const [openDropdown, setOpenDropdown] = useState<boolean>(false);
-  const [category, setCategory] = useState<string>('');
+  const [category, setCategory] = useState<EnquiryCategoryType>({
+    id: '',
+    category: '',
+  });
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
   const dropdownRef = useRef<HTMLDivElement>(null);
 
+  const enquireMutation = useMutation({
+    mutationFn: postInquiries,
+  });
+
   const isFormValid = () => {
     const titleValid = title.trim().length >= 3 && title.trim().length <= 100;
-    const categoryValid = category.trim().length > 0;
+    const categoryValid = category.id.trim().length > 0;
     const contentValid =
       content.trim().length >= 3 && content.trim().length <= 5000;
     return titleValid && categoryValid && contentValid;
   };
 
   const handleSubmit = () => {
-    console.log('제목:', title);
-    console.log('카테고리:', category);
-    console.log('문의 내용:', content);
+    const data = {title, category: category.id, content};
+    enquireMutation.mutate(data);
+    console.log(data);
   };
 
   useClickOutside({
@@ -59,7 +73,7 @@ const EnquirePage = () => {
             <div
               className='h-25 border border-solid border-[#000] focus:outline-0 text-[#000] text-xl leading-[110%] flex justify-between items-center overflow-hidden'
               onClick={() => setOpenDropdown((prev) => !prev)}>
-              <p>{category}</p>
+              <p>{category.category}</p>
               <ChevronRight className='rotate-90 w-30 h-30' />
             </div>
             {openDropdown && (
@@ -104,6 +118,23 @@ const EnquirePage = () => {
           </button>
         </div>
       </div>
+
+      {/* 상태 모달 & 오버레이 */}
+      {enquireMutation.isPending && <LoadingOverlay />}
+      {enquireMutation.isSuccess && (
+        <Modal
+          content='성공적으로 문의 메일을 보냈습니다.'
+          rightText='확인'
+          onRightClick={() => navigate(-1)}
+        />
+      )}
+      {enquireMutation.isError && (
+        <Modal
+          content='문의 메일을 발송 중 오류가 발생했습니다.'
+          rightText='확인'
+          onRightClick={() => enquireMutation.reset()}
+        />
+      )}
     </div>
   );
 };
@@ -112,7 +143,7 @@ const CategoryDropdown = ({
   setCategory,
   setOpenDropdown,
 }: {
-  setCategory: (category: string) => void;
+  setCategory: (category: EnquiryCategoryType) => void;
   setOpenDropdown: (open: boolean) => void;
 }) => {
   return (
@@ -122,7 +153,7 @@ const CategoryDropdown = ({
           key={category.id}
           className='hover:cursor-pointer'
           onClick={() => {
-            setCategory(category.id);
+            setCategory(category);
             setOpenDropdown(false);
           }}>
           {category.category}

--- a/src/pages/setting/EnquirePage.tsx
+++ b/src/pages/setting/EnquirePage.tsx
@@ -7,7 +7,23 @@ import useClickOutside from '@/hooks/useClickOutside';
 const EnquirePage = () => {
   const [openDropdown, setOpenDropdown] = useState<boolean>(false);
   const [category, setCategory] = useState<string>('');
+  const [title, setTitle] = useState<string>('');
+  const [content, setContent] = useState<string>('');
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const isFormValid = () => {
+    const titleValid = title.trim().length >= 3 && title.trim().length <= 100;
+    const categoryValid = category.trim().length > 0;
+    const contentValid =
+      content.trim().length >= 3 && content.trim().length <= 5000;
+    return titleValid && categoryValid && contentValid;
+  };
+
+  const handleSubmit = () => {
+    console.log('제목:', title);
+    console.log('카테고리:', category);
+    console.log('문의 내용:', content);
+  };
 
   useClickOutside({
     ref: dropdownRef,
@@ -26,6 +42,10 @@ const EnquirePage = () => {
           <p className='text-[#000] text-xl font-medium leading-[110%]'>제목</p>
           <input
             type='text'
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            minLength={3}
+            maxLength={100}
             className='h-25 max-w-436 grow border border-solid border-[#000] focus:outline-0 text-[#000] text-xl leading-[110%]'
           />
         </div>
@@ -57,16 +77,15 @@ const EnquirePage = () => {
             문의 내용
           </p>
         </div>
-        <form
-          className='flex flex-col items-center gap-14 self-stretch'
-          onSubmit={(e) => {
-            e.preventDefault();
-            console.log('todo : 문의 api 연동하기');
-          }}>
+        <div className='flex flex-col items-center gap-14 self-stretch'>
           <textarea
             aria-label='enquiry-content'
             name='enquiry-content'
             id='enquiry-content'
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            minLength={3}
+            maxLength={5000}
             placeholder='문의 내용을 작성하세요.'
             className='border-b border-solid border-primary-5 py-16 px-22 
             placeholder:text-gray-2 text-[#000] text-[23px] leading-[110%] resize-none w-full h-398 focus:outline-0'
@@ -74,10 +93,16 @@ const EnquirePage = () => {
 
           <button
             type='submit'
-            className='py-[8.5px] px-28 rounded-[5px] border border-solid border-primary bg-white_1 text-primary text-2xl font-medium leading-[110%]'>
+            onClick={handleSubmit}
+            disabled={!isFormValid()}
+            className={`py-[8.5px] px-28 rounded-[5px] border border-solid text-2xl font-medium leading-[110%] ${
+              isFormValid()
+                ? 'border-primary bg-white_1 text-primary hover:cursor-pointer'
+                : 'border-gray-300 bg-gray-100 text-gray-400 cursor-not-allowed'
+            }`}>
             등록하기
           </button>
-        </form>
+        </div>
       </div>
     </div>
   );
@@ -97,7 +122,7 @@ const CategoryDropdown = ({
           key={category.id}
           className='hover:cursor-pointer'
           onClick={() => {
-            setCategory(category.category);
+            setCategory(category.id);
             setOpenDropdown(false);
           }}>
           {category.category}

--- a/src/types/enquiry.ts
+++ b/src/types/enquiry.ts
@@ -1,0 +1,10 @@
+export type EnquiryType = {
+  title: string;
+  category: string;
+  content: string;
+};
+
+export type EnquiryCategoryType = {
+  id: string;
+  category: string;
+};


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#114 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

이 pull request는 사용자가 **"문의하기"** 페이지를 통해 문의를 제출할 수 있는 기능을 추가하고, 백엔드 API를 연동하며, 관련 타입 및 상수를 리팩토링하는 내용을 담고 있습니다. 주요 변경 사항은 API 통합, UI 개선, 그리고 더 나은 유지보수성과 사용자 경험을 위한 타입 업데이트입니다.



### **문의 제출 기능 통합**

- `mypageApi.ts`에 **`postInquiries` API 함수를 추가**하여 문의 데이터를 백엔드 엔드포인트로 전송하며, 사용자에게 친숙한 오류 메시지 처리 기능이 포함되어 있습니다.
- `urls.ts`에 새로운 문의 엔드포인트 **`MYPAGE_INQUIRIES`를 등록**하여 API 호출을 지원합니다.



### **UI 및 폼 핸들링 개선**

- "문의하기" 페이지는 **React Query의 `useMutation`을 사용하여 문의를 제출**하도록 업데이트되었습니다. 여기에는 폼 유효성 검사, 제목과 내용에 대한 제어되는 입력(controlled inputs), 그리고 성공/오류 상태를 보여주는 피드백 모달이 포함됩니다.
- 카테고리 선택 기능을 문자열 대신 **객체(`EnquiryCategoryType`)를 사용하도록 변경**하여 드롭다운 및 제출 로직의 타입 안정성과 명확성을 높였습니다.



### **타입 및 상수 리팩토링**

- `enquiry.ts`에 **`EnquiryType` 및 `EnquiryCategoryType`이라는 새로운 타입을 도입**하여 문의 데이터 구조를 표준화했습니다.
- `constants/enquiry.ts`의 **`enquiryCategories`를 문자열 ID를 사용하도록 리팩터링**하여 더 나은 의미론적 표현과 API 호환성을 확보했습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->

https://github.com/user-attachments/assets/d253c0f6-d15c-401e-bd2f-886d1b3c7c9a



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->