### PR TITLE
feat/#115: 로그인/로그아웃 진행중 화면 구현

### DIFF
--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -10,6 +10,8 @@ import {postLogin} from '@/api/authApi';
 import {useMutation} from '@tanstack/react-query';
 import {useAuthStore} from '@/stores/authStore';
 import {getMypageInfo} from '@/api/mypageApi';
+import LoadingOverlay from '@/components/global/LoadingOverlay';
+import Modal from '@/components/global/Modal';
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -29,7 +31,6 @@ const LoginPage = () => {
       login(loginRes.accessToken, loginRes.refreshToken, userInfo);
       navigate('/');
     },
-    onError: (error) => alert(error.message),
   });
 
   const handleLoginClick = () => {
@@ -93,6 +94,16 @@ const LoginPage = () => {
         {/* brands */}
         <AuthBrandBadges />
       </div>
+
+      {/* 상태 모달 & 오버레이 */}
+      {loginMutation.isPending && <LoadingOverlay />}
+      {loginMutation.isError && (
+        <Modal
+          content={loginMutation.error.message}
+          rightText='확인'
+          onRightClick={() => loginMutation.reset()}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/setting/SettingSupportPage.tsx
+++ b/src/pages/setting/SettingSupportPage.tsx
@@ -1,5 +1,6 @@
 import {deleteWithdraw, postLogout} from '@/api/authApi';
 import ChevronRight from '@/assets/arrows/chevron-right.svg?react';
+import LoadingOverlay from '@/components/global/LoadingOverlay';
 import Modal from '@/components/global/Modal';
 import {withdrawComplete, withdrawing} from '@/constants/withdraw';
 import {useAuthStore} from '@/stores/authStore';
@@ -109,6 +110,10 @@ const SettingSupportPage = () => {
             logout();
           }}
         />
+      )}
+
+      {(logoutMutation.isPending || withdrawMutation.isPending) && (
+        <LoadingOverlay />
       )}
     </div>
   );


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#115 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

이 pull request는 로그인 및 설정 지원 페이지에 **로딩 오버레이와 오류 모달을 추가**하여 인증 및 계정 관련 작업에 대한 사용자 피드백을 개선합니다. 이러한 변경 사항은 비동기 작업 중에 명확한 시각적 지표를 제공하고 더 유용한 정보의 오류 처리를 통해 사용자 경험을 향상시킵니다.



### **사용자 피드백 개선**

- `LoginPage.tsx`에 `LoadingOverlay` 및 `Modal` 컴포넌트를 추가하여, **로그인 중 로딩 표시기를 보여주고 브라우저 경고창(alert) 대신 모달에 오류를 표시**하도록 했습니다.
- `SettingSupportPage.tsx`에 `LoadingOverlay`를 추가하여 **진행 중인 로그아웃 또는 회원 탈퇴 작업을 나타내도록** 했습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->

https://github.com/user-attachments/assets/616886a7-3095-4fcc-862a-119ecb85ddc8



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->