### PR TITLE
deploy: 2025년 8월 16일 배포 - 2

### DIFF
--- a/src/pages/community/CommunityMainPage.tsx
+++ b/src/pages/community/CommunityMainPage.tsx
@@ -6,11 +6,8 @@ import School from '@/assets/community/tip-post-school.svg?react';
 import Rocket from '@/assets/community/hot-post-rocket.svg?react';
 import MusicalNote from '@/assets/community/daily-post-musical-note.svg?react';
 import PlayMagazine from '@/components/community/magazine/PlayMagazine';
-import useCommunityListNavigation from '@/hooks/useCommunityListNavigation';
 
 const CommunityMainPage = () => {
-  const {goToCommunityCategory} = useCommunityListNavigation();
-
   return (
     <div className='flex flex-col gap-30 mb-12 px-16'>
       {/** hot 게시물 */}
@@ -19,7 +16,6 @@ const CommunityMainPage = () => {
         title='HOT 게시물'
         posts={mockPosts}
         variant='hot'
-        onClick={() => goToCommunityCategory('hot')}
       />
 
       {/** 나눔 거래 게시판 */}
@@ -34,7 +30,6 @@ const CommunityMainPage = () => {
         title='일상 게시물'
         posts={mockPosts.filter((post) => post.category === '일상')}
         variant='daily'
-        onClick={() => goToCommunityCategory('daily')}
       />
 
       {/** 꿀팁 게시물 */}
@@ -43,7 +38,6 @@ const CommunityMainPage = () => {
         title='꿀팁 게시물'
         posts={mockPosts.filter((post) => post.category === '꿀팁')}
         variant='tip'
-        onClick={() => goToCommunityCategory('tip')}
       />
 
       {/** 공연 매거진 */}


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->


<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

이 pull request는 커뮤니티 카테고리 관련 네비게이션 로직을 제거하여 **`CommunityMainPage` 컴포넌트를 간소화**합니다. 주요 변경 사항은 `useCommunityListNavigation` 훅과 관련 클릭 핸들러를 삭제하여, 컴포넌트가 더 이상 네비게이션을 처리하지 않고 게시물 목록을 표시하는 역할에만 집중하도록 한 것입니다.

---

### **컴포넌트 간소화**

- `CommunityMainPage.tsx`에서 `useCommunityListNavigation` 임포트를 제거하여 불필요한 네비게이션 로직을 없앴습니다.
- 이전에 `PlayMagazine` 컴포넌트에서 `hot`, `daily`, `tip`과 같은 **다양한 커뮤니티 카테고리로 네비게이션을 트리거하던 `onClick` 핸들러들을 제거**했습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->