### PR TITLE
fix/#133: 공연 평점 순위 조회 범위를 사용자 기준으로 한정

### DIFF
--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -45,5 +45,5 @@ export const ENDPOINT = {
   ARCHIVE_CREATE: '/api/v1/archive',
   ARCHIVE_UPDATE: (archiveId: number) => `/api/v1/archive/${archiveId}`,
   ARCHIVE_DELETE: (archiveId: number) => `/api/v1/archive/${archiveId}`,
-  ARCHIVE_TOP_RATING: '/api/v1/archives/top-rating',
+  ARCHIVE_TOP_RATING: '/api/v2/archives/top-rating',
 };


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
close #133 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
사용자가 로그인한 상탱에서 아카이빙 페이지를 들어가면, 해당 사용자의 공연 평점 순위 데이터가 렌더링되어야 하지만 전체 사용자를 기준으로 설정되어 있는 문제를 해결했습니다.

* 경로 수정 작업 진행했습니다. 기존 경로 v1 -> v2로 수정 
<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->