### PR TITLE
deploy: 2025년 8월 16일 배포 - 4

### DIFF
--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -45,5 +45,5 @@ export const ENDPOINT = {
   ARCHIVE_CREATE: '/api/v1/archive',
   ARCHIVE_UPDATE: (archiveId: number) => `/api/v1/archive/${archiveId}`,
   ARCHIVE_DELETE: (archiveId: number) => `/api/v1/archive/${archiveId}`,
-  ARCHIVE_TOP_RATING: '/api/v1/archives/top-rating',
+  ARCHIVE_TOP_RATING: '/api/v2/archives/top-rating',
 };

--- a/src/components/community/post/SharePostList.tsx
+++ b/src/components/community/post/SharePostList.tsx
@@ -37,8 +37,6 @@ const SharePostList = () => {
           />
         ))}
       </ul>
-      {/** 더보기 버튼 */}
-      <LoadMoreButton onClick={goToShareList} />
     </div>
   );
 };


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->


<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

이 pull request는 **최고 평점 아카이브를 가져오는 API 엔드포인트를 업데이트**하고, 공유 게시물 목록 컴포넌트에서 "더보기" 버튼을 제거합니다. 이러한 변경은 주로 커뮤니티 게시물 공유 기능에서 데이터를 가져오고 표시하는 방식에 영향을 줍니다.

---

### **주요 변경 사항**

- **API 엔드포인트 업데이트:** `src/api/urls.ts`에서 `ARCHIVE_TOP_RATING` 엔드포인트를 API 버전 2(`api/v2/archives/top-rating`)를 사용하도록 변경하여, 업데이트된 백엔드 라우트로 요청을 보냅니다.
- **UI 업데이트:** `src/components/community/post/SharePostList.tsx`의 `SharePostList` 컴포넌트에서 `LoadMoreButton`을 제거하여 UI를 간소화했습니다. 이에 따라 사용자가 추가 공유 게시물을 탐색하는 방식이 달라질 수 있습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->