### PR TITLE
feat/#127: 알림함 API 연동

### DIFF
--- a/src/api/notificationApi.ts
+++ b/src/api/notificationApi.ts
@@ -1,0 +1,8 @@
+import type {NotificationResponse} from '@/types/notification';
+import {privateAxios} from './axios';
+import {ENDPOINT} from './urls';
+
+export const getNotification = async (): Promise<NotificationResponse> => {
+  const res = await privateAxios.get(ENDPOINT.NOTIFICATION);
+  return res.data;
+};

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -46,4 +46,9 @@ export const ENDPOINT = {
   ARCHIVE_UPDATE: (archiveId: number) => `/api/v1/archive/${archiveId}`,
   ARCHIVE_DELETE: (archiveId: number) => `/api/v1/archive/${archiveId}`,
   ARCHIVE_TOP_RATING: '/api/v2/archives/top-rating',
+  //search
+  SEARCH_POPULAR: '/api/v1/search/popular',
+  SEARCH: '/api/v1/search',
+  //notification
+  NOTIFICATION: '/api/v1/notifications',
 };

--- a/src/components/global/NotificationCard.tsx
+++ b/src/components/global/NotificationCard.tsx
@@ -1,5 +1,7 @@
 import Comment from '@/assets/notification/comment.svg?react';
+import formatKoreanTime from '@/util/formatKoreanTime';
 import {useNavigate} from 'react-router-dom';
+
 /**
  * 알림 카드 컴포넌트
  * 사용자가 작성한 커뮤니티 글의 댓글에 대한 알림
@@ -18,6 +20,7 @@ const NotificationCard = ({
   postId,
 }: NotificationProps) => {
   const navigate = useNavigate();
+
   return (
     <div
       className='w-[466px] flex items-center justify-between bg-[#DDE1E6]/75 rounded-[20px] py-10 px-20 gap-20 cursor-pointer h-62'
@@ -31,7 +34,7 @@ const NotificationCard = ({
       </div>
 
       <span className='text-[#3C3C3C]/80 text-[13px] min-w-[60px] text-right shrink-0'>
-        {formattedDate}
+        {formatKoreanTime(formattedDate)}
       </span>
     </div>
   );

--- a/src/components/global/NotificationCard.tsx
+++ b/src/components/global/NotificationCard.tsx
@@ -1,31 +1,32 @@
-import formatKoreanTime from '@/util/formatKoreanTime';
 import Comment from '@/assets/notification/comment.svg?react';
+import {useNavigate} from 'react-router-dom';
 /**
  * 알림 카드 컴포넌트
  * 사용자가 작성한 커뮤니티 글의 댓글에 대한 알림
  * 사용자가 작성한 댓글의 답글에 대한 알림
  */
 interface NotificationProps {
-  postTitle: string;
-  createdAt: string;
-  type: string;
+  title: string;
+  formattedDate: string;
+  content: string;
+  postId: number;
 }
-const NotificationCard = ({postTitle, createdAt, type}: NotificationProps) => {
-  const message =
-    type === 'COMMENT_ON_MY_POST'
-      ? '누군가 댓글을 남겼어요'
-      : '댓글에 누군가 답장을 했어요';
-  const formattedDate = formatKoreanTime(createdAt);
-
+const NotificationCard = ({
+  title,
+  formattedDate,
+  content,
+  postId,
+}: NotificationProps) => {
+  const navigate = useNavigate();
   return (
-    <div className='w-[466px] flex items-center justify-between bg-[#DDE1E6]/75 rounded-[20px] py-10 px-20 gap-20 cursor-pointer h-62'>
+    <div
+      className='w-[466px] flex items-center justify-between bg-[#DDE1E6]/75 rounded-[20px] py-10 px-20 gap-20 cursor-pointer h-62'
+      onClick={() => navigate(`/community/${postId}`)}>
       <div className='flex flex-row gap-20 items-center flex-1 min-w-0'>
         <Comment className='w-27' />
         <div className='flex flex-col min-w-0'>
-          <span className='font-semibold text-[18px] truncate'>
-            {postTitle}
-          </span>
-          <span className='text-[12px]'>{message}</span>
+          <span className='font-semibold text-[18px] truncate'>{title}</span>
+          <span className='text-[12px]'>{content}</span>
         </div>
       </div>
 

--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -1,0 +1,14 @@
+import {getNotification} from '@/api/notificationApi';
+import type {Notification} from '@/types/notification';
+import {useQuery} from '@tanstack/react-query';
+
+export const useNotifications = () => {
+  return useQuery<Notification[], Error>({
+    queryKey: ['notifications'],
+    queryFn: async () => {
+      const res = await getNotification();
+      return res.data;
+    },
+    staleTime: 1000 * 60,
+  });
+};

--- a/src/pages/NotificationPage.tsx
+++ b/src/pages/NotificationPage.tsx
@@ -1,19 +1,50 @@
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
 import NotificationCard from '@/components/global/NotificationCard';
-import {mockNotifications} from '@/mocks/mockNotification';
+import {useNotifications} from '@/hooks/useNotification';
+import '@/styles/skeleton.css';
+
+const SkeletonNotificationCard = () => (
+  <div className='w-[466px] h-62 rounded-[20px] mb-4 flex items-center skeleton-shimmer'></div>
+);
 
 const NotificationPage = () => {
-  const sortedNotifications = [...mockNotifications].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  );
+  const {data: notifications, isLoading, error} = useNotifications();
+  const skeletonCount = notifications?.length || 5;
+  if (error)
+    return (
+      <div className='flex justify-center py-40'>
+        오류 발생: {error.message}
+      </div>
+    );
   return (
     <div className='flex flex-col px-30 gap-20'>
       <BackButtonTitleHeader title='알림' between={true} />
-      <ul className='flex flex-col gap-15 pb-30 items-center'>
-        {sortedNotifications.map((notification) => (
-          <NotificationCard key={notification.id} {...notification} />
-        ))}
-      </ul>
+
+      {isLoading ? (
+        <ul className='flex flex-col gap-15 pb-30 items-center'>
+          {Array.from({length: skeletonCount}).map((_, idx) => (
+            <SkeletonNotificationCard key={idx} />
+          ))}
+        </ul>
+      ) : !notifications || notifications.length === 0 ? (
+        <div className='flex flex-col items-center py-40'>
+          <span className='text-gray-400 text-[16px]'>
+            현재 알림이 없습니다.
+          </span>
+        </div>
+      ) : (
+        <ul className='flex flex-col gap-15 pb-30 items-center'>
+          {notifications.map((notification) => (
+            <NotificationCard
+              key={notification.postId}
+              title={notification.title}
+              formattedDate={notification.formattedDate}
+              content={notification.content}
+              postId={notification.postId}
+            />
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,0 +1,12 @@
+export interface Notification {
+  postId: number;
+  title: string;
+  content: string;
+  formattedDate: string;
+}
+
+export interface NotificationResponse {
+  status: string;
+  timestamp: string;
+  data: Notification[];
+}

--- a/src/util/formatKoreanTime.ts
+++ b/src/util/formatKoreanTime.ts
@@ -4,11 +4,12 @@ import {
   isYesterday,
   differenceInHours,
   differenceInMinutes,
+  parse,
 } from 'date-fns';
 import {ko} from 'date-fns/locale';
 
 const formatKoreanTime = (dateString: string) => {
-  const date = new Date(dateString);
+  const date = parse(dateString, 'yyyy/MM/dd HH:mm', new Date());
   const now = new Date();
   const hoursDiff = differenceInHours(now, date);
 
@@ -16,18 +17,15 @@ const formatKoreanTime = (dateString: string) => {
   if (hoursDiff < 24) {
     const minutesDiff = differenceInMinutes(now, date);
 
-    /** 1시간 미만이면 분 단위 */
     if (minutesDiff < 60) {
       return `${minutesDiff}분 전`;
     } else {
       return `${hoursDiff}시간 전`;
     }
-    /** 오늘, 어제인 경우 한정 명시 */
   } else if (isToday(date)) {
     return `오늘 ${format(date, 'a h:mm', {locale: ko})}`;
   } else if (isYesterday(date)) {
     return `어제 ${format(date, 'a h:mm', {locale: ko})}`;
-    /** 그 외 날짜 전체 출력 */
   } else {
     return format(date, 'M월 d일 a h:mm', {locale: ko});
   }


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
close #127 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
알림함 API 기능들을 연결했습니다.

* 알림 get API 함수 `notificationApi.ts`
  * 관련 쿼리 훅 `useNotification.ts`
* API 응답 formattedDate에 맞게 한국 시간으로 변경하는 유틸 함수 수정  
  * "2025/08/05 23:37" 같은 문자열도 안정적으로 파싱되게끔 parse 기능 추가
* 로딩 중 스켈레톤 UI 표시 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
알림 카드 클릭 시 community/postId 경로로 연결되게 구현해 뒀는데, 추후 커뮤니티 API 연동 후 수정이 필요할 것 같아요. community/daily/id 와 같이 포스트를 연결할지, postId로만 카테고리를 구분할지 모호해서 커뮤니티 연동 후 함께 수정해 두겠습니다


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->