### PR TITLE
style/#143: 전체 페이지 그림자 스타일 개선

### DIFF
--- a/src/layout/CommunityContentLayout.tsx
+++ b/src/layout/CommunityContentLayout.tsx
@@ -9,7 +9,7 @@ import {Outlet} from 'react-router-dom';
 const CommunityContentLayout = () => {
   return (
     <div className='w-full min-h-screen flex justify-center overflow-x-hidden'>
-      <div className='relative w-full max-w-[600px] pb-[90px]'>
+      <div className='relative w-full max-w-[600px] pb-[90px] shadow-2xl'>
         <header className='w-full max-w-[600px] fixed top-0 left-1/2 -translate-x-1/2 z-50'>
           <ContentHeader showShare={true} />
         </header>

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -38,7 +38,7 @@ const LoginPage = () => {
   };
 
   return (
-    <div className='w-full sm:w-[600px] mx-auto bg-white'>
+    <div className='w-full sm:w-[600px] mx-auto bg-white shadow-2xl min-h-screen'>
       {/* 헤더 */}
       <PageHeader
         title={'로그인'}

--- a/src/pages/auth/SignupCompletePage.tsx
+++ b/src/pages/auth/SignupCompletePage.tsx
@@ -10,7 +10,7 @@ const SignupCompletePage = () => {
   const {user} = useAuthStore();
 
   return (
-    <div className='w-full sm:w-[600px] mx-auto bg-white'>
+    <div className='w-full sm:w-[600px] mx-auto bg-white shadow-2xl min-h-screen'>
       <PageHeader
         title='회원가입'
         onLeftClick={() => navigate('/signup-form')}

--- a/src/pages/auth/SignupConditionPage.tsx
+++ b/src/pages/auth/SignupConditionPage.tsx
@@ -52,7 +52,7 @@ const SignupConditionPage = () => {
   };
 
   return (
-    <div className='w-full sm:w-[600px] mx-auto bg-white'>
+    <div className='w-full sm:w-[600px] mx-auto bg-white min-h-screen shadow-2xl'>
       <PageHeader
         title='회원가입'
         onLeftClick={() => navigate('/login')}

--- a/src/pages/auth/SignupFormPage.tsx
+++ b/src/pages/auth/SignupFormPage.tsx
@@ -333,7 +333,7 @@ const SignupFormPage = () => {
     renderNicknameMessage();
 
   return (
-    <div className='w-full sm:w-[600px] mx-auto bg-white'>
+    <div className='w-full sm:w-[600px] mx-auto bg-white shadow-2xl min-h-screen'>
       <PageHeader
         title={'회원가입'}
         onLeftClick={() => navigate('/signup-condition')}


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
close #143 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
메인 화면과 동일하게 로그인, 회원가입, 커뮤니티 상세 페이지 외곽에 shadow-2xl 스타일을 추가했습니다.
로그인/회원가입 폼 페이지에서는 min-h-screen 속성을 적용하여 뷰포트 height 전체 기준으로 shadow 스타일이 적용되게 구현했습니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
<img width="942" height="1402" alt="image" src="https://github.com/user-attachments/assets/557d2da1-0875-49ef-97d1-45a16ce8bbde" />
<img width="969" height="1408" alt="image" src="https://github.com/user-attachments/assets/cb7f616d-72ab-4201-8e47-d5322aaeb123" />
<img width="1113" height="1414" alt="image" src="https://github.com/user-attachments/assets/f9912f2b-8aac-463f-ba72-1f6419e95076" />


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->