### PR TITLE
feat/#122: 내가 스크랩한 글, 매거진 API 연결

### DIFF
--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -72,4 +72,8 @@ export const ENDPOINT = {
     `/api/v1/magazines/${magazineId}/scraps`,
   MAGAZINE_LIKE: (magazineId: number) =>
     `/api/v1/magazines/${magazineId}/likes`,
+
+  //user
+  USER_MAGAZINE: '/api/v1/users/magazines',
+  USER_COMMUNITIES: '/api/v1/users/communities',
 };

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -1,0 +1,53 @@
+import type {Magazine, Post} from '@/types/community';
+import {privateAxios} from './axios';
+import {ENDPOINT} from './urls';
+
+interface UserMagazinesResponse {
+  status: string;
+  timestamp: string;
+  data: {
+    list: Magazine[];
+    currentPage: number;
+    pageSize: number;
+    totalElements: number;
+    totalPages: number;
+  };
+}
+
+interface UserCommunitiesResponse {
+  status: string;
+  timestamp: string;
+  data: {
+    list: Post[];
+    currentPage: number;
+    pageSize: number;
+    totalElements: number;
+    totalPages: number;
+  };
+}
+
+export const getUserMagazines = async (
+  page: number = 1,
+  size: number = 6
+): Promise<UserMagazinesResponse> => {
+  const response = await privateAxios.get<UserMagazinesResponse>(
+    ENDPOINT.USER_MAGAZINE,
+    {
+      params: {page, size},
+    }
+  );
+  return response.data;
+};
+
+export const getUserCommunities = async (
+  page: number = 1,
+  size: number = 6
+): Promise<UserCommunitiesResponse> => {
+  const response = await privateAxios.get<UserCommunitiesResponse>(
+    ENDPOINT.USER_COMMUNITIES,
+    {
+      params: {page, size},
+    }
+  );
+  return response.data;
+};

--- a/src/components/archive/ScrappedMagazine.tsx
+++ b/src/components/archive/ScrappedMagazine.tsx
@@ -1,28 +1,37 @@
-import {mockMagazine} from '@/mocks/mockMagazine';
+import useCommunityNavigation from '@/hooks/useCommunityNavigation';
 import PostCardItem from '../community/post/PostCardItem';
 import {useHorizontalScroll} from '@/hooks/useHorizontalScroll';
+import type {Magazine} from '@/types/community';
 
-const ScrappedMagazine = () => {
-  const bookmarkedMagazines = mockMagazine.filter(
-    (magazine) => magazine.isBookmarked
-  );
+interface ScrappedMagazineProps {
+  magazines: Magazine[];
+}
+
+const ScrappedMagazine = ({magazines}: ScrappedMagazineProps) => {
   const listWrapperRef = useHorizontalScroll();
+  const {goToMagazineDetail} = useCommunityNavigation();
   return (
-    <ul
-      className='px-15 flex flex-row overflow-x-auto gap-17'
-      ref={listWrapperRef}>
-      {bookmarkedMagazines.map((post) => (
-        <PostCardItem
-          title={post.title}
-          subtitle={post.subtitle}
-          category={post.category}
-          isBookmarked={post.isBookmarked}
-          isScrapMagazine={true}
-          placeholderText='공연 매거진 임시 이미지'
-        />
-      ))}
-    </ul>
+    <div className='flex flex-col gap-20'>
+      <div className='flex flex-row justify-between items-end'></div>
+
+      <ul
+        className='px-15 flex flex-row overflow-x-auto gap-17'
+        ref={listWrapperRef}>
+        {magazines.map((post) => (
+          <PostCardItem
+            key={post.id}
+            title={post.title}
+            subTitle={post.subTitle}
+            category={post.category}
+            isScraped={post.isScraped}
+            imageUrl={post.imageUrl}
+            isScrapMagazine={true}
+            placeholderText={post.title}
+            onClick={() => goToMagazineDetail(post.id)}
+          />
+        ))}
+      </ul>
+    </div>
   );
 };
-
 export default ScrappedMagazine;

--- a/src/hooks/useUserContents.ts
+++ b/src/hooks/useUserContents.ts
@@ -1,0 +1,22 @@
+import {getUserCommunities, getUserMagazines} from '@/api/userApi';
+import {keepPreviousData, useQuery} from '@tanstack/react-query';
+
+// 스크랩 매거진 훅
+export const useUserMagazines = (page: number = 1, size: number = 6) => {
+  return useQuery({
+    queryKey: ['userMagazines', page, size],
+    queryFn: () => getUserMagazines(page, size),
+    placeholderData: keepPreviousData,
+    staleTime: 1000 * 60,
+  });
+};
+
+// 스크랩 글 훅
+export const useUserCommunities = (page: number = 1, size: number = 6) => {
+  return useQuery({
+    queryKey: ['userCommunities', page, size],
+    queryFn: () => getUserCommunities(page, size),
+    placeholderData: keepPreviousData,
+    staleTime: 1000 * 60,
+  });
+};

--- a/src/pages/ScrappedMagazinePage.tsx
+++ b/src/pages/ScrappedMagazinePage.tsx
@@ -1,53 +1,55 @@
-import {useState, useEffect} from 'react';
+import {useState} from 'react';
 import Pagination from 'react-js-pagination';
-import {mockMagazine} from '@/mocks/mockMagazine';
 import PostCardItem from '@/components/community/post/PostCardItem';
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
+import {useUserMagazines} from '@/hooks/useUserContents';
+import useCommunityNavigation from '@/hooks/useCommunityNavigation';
+import LoadingSpinner from '@/components/ui/LoadingSpinner';
 
 const ITEMS_PER_PAGE = 6;
 
 const ScrappedMagazinePage = () => {
-  const scrappedMagazine = mockMagazine.filter(
-    (magazine) => magazine.isBookmarked
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const {data, isError, isLoading} = useUserMagazines(
+    currentPage,
+    ITEMS_PER_PAGE
   );
+  const magazines = data?.data.list ?? [];
+  const totalItemsCount = data?.data.totalElements ?? 0;
+  const {goToMagazineDetail} = useCommunityNavigation();
 
-  const [currentPage, setCurrentPage] = useState(1);
-  const totalItemsCount = scrappedMagazine.length;
-
-  const indexOfLastItem = currentPage * ITEMS_PER_PAGE;
-  const indexOfFirstItem = indexOfLastItem - ITEMS_PER_PAGE;
-  const currentItems = scrappedMagazine.slice(
-    indexOfFirstItem,
-    indexOfLastItem
-  );
-
-  useEffect(() => {
+  const handlePageChange = (pageNumber: number) => {
+    setCurrentPage(pageNumber);
     window.scrollTo({
       top: 0,
       behavior: 'smooth',
     });
-  }, [currentPage]);
-
-  const handlePageChange = (pageNumber: number) => {
-    setCurrentPage(pageNumber);
   };
-
+  if (isLoading) return <LoadingSpinner />;
+  if (isError)
+    return (
+      <div className='flex justify-center text-gray-2 text-sm'>
+        매거진을 불러오는 데 실패했습니다.
+      </div>
+    );
   return (
-    <div className='flex flex-col gap-40'>
+    <div className='flex flex-col gap-40 justify-center'>
       {/* 상단 */}
       <BackButtonTitleHeader title='스크랩한 매거진 모아보기' between />
 
       {/* 리스트 */}
-      <ul className='flex flex-wrap justify-center gap-y-60 gap-x-24'>
-        {currentItems.map((magazine, idx) => (
+      <ul className='flex flex-wrap gap-y-60 gap-x-24 px-35'>
+        {magazines.map((magazine) => (
           <PostCardItem
-            key={idx}
+            key={magazine.id}
             title={magazine.title}
-            subtitle={magazine.subtitle}
+            subTitle={magazine.subTitle}
             category={magazine.category}
-            isBookmarked={magazine.isBookmarked}
+            isScraped={magazine.isScraped}
+            imageUrl={magazine.imageUrl}
             isScrapMagazine={true}
-            placeholderText='매거진 임시 이미지'
+            placeholderText={magazine.title}
+            onClick={() => goToMagazineDetail(magazine.id)}
           />
         ))}
       </ul>

--- a/src/pages/ScrappedPostPage.tsx
+++ b/src/pages/ScrappedPostPage.tsx
@@ -1,40 +1,48 @@
-import {useState, useEffect} from 'react';
+import {useState} from 'react';
 import Pagination from 'react-js-pagination';
-import {mockPosts} from '@/mocks/mockPosts';
+
 import PostListItem from '@/components/community/post/PostListItem';
 import BackButtonTitleHeader from '@/components/global/BackButtonTitleHeader';
+import {useUserCommunities} from '@/hooks/useUserContents';
+import LoadingSpinner from '@/components/ui/LoadingSpinner';
 const ITEMS_PER_PAGE = 9;
 
 const ScrappedPostPage = () => {
-  const scrappedPost = mockPosts.filter((post) => post.isScrapped === true);
-  const [currentPage, setCurrentPage] = useState(1);
-  const totalItemsCount = scrappedPost.length;
-  const indexOfLastItem = currentPage * ITEMS_PER_PAGE;
-  const indexOfFirstItem = indexOfLastItem - ITEMS_PER_PAGE;
-  const currentItems = scrappedPost.slice(indexOfFirstItem, indexOfLastItem);
-
-  useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
-  }, [currentPage]);
-
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const {data, isLoading, isError} = useUserCommunities(
+    currentPage,
+    ITEMS_PER_PAGE
+  );
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };
+  if (isLoading) return <LoadingSpinner />;
+  if (isError)
+    return (
+      <div className='text-sm text-red justify-center'>
+        스크랩한 글을 불러오지 못했습니다.
+      </div>
+    );
 
+  const posts = data?.data.list ?? [];
+  const totalItemsCount = data?.data.totalElements ?? 0;
   return (
     <div className='flex flex-col gap-40'>
       {/* 상단 */}
       <BackButtonTitleHeader title='스크랩한 글 모아보기' between />
 
       {/* 리스트 */}
-      <ul className='flex flex-col gap-10'>
-        {currentItems.map((post, idx) => (
-          <PostListItem key={idx} post={post} />
-        ))}
-      </ul>
+      {posts.length > 0 ? (
+        <ul className='flex flex-col gap-10'>
+          {posts.map((post) => (
+            <PostListItem key={post.id} post={post} />
+          ))}
+        </ul>
+      ) : (
+        <div className='text-gray-500 text-sm text-center'>
+          스크랩한 글이 없습니다.
+        </div>
+      )}
 
       {/* 페이지네이션 */}
       <div className='flex justify-center'>


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->

close #122 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
내가 스크랩한 글, 매거진 페이지네이션과 아카이빙 - 미리보기 부분 API 를 연결했습니다.

* API 함수 작성 `userApi.ts` 
  * 쿼리 훅 `useUserContents.ts`
* 아카이빙 - 메인 페이지에 스켈레톤 UI를 적용했습니다.
* 유저가 스크랩한 글/매거진이 없는 경우에는 <더 보기> 아이콘이 나타나지 않게 수정했습니다.
* 전체 페이지네이션 로딩 표시는 로딩 스피너로 대체했습니다. 

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->
![Animation](https://github.com/user-attachments/assets/71899ddd-38f9-481a-99de-4455abb50a9f)


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->