### PR TITLE
feat/#173: 로그인 유지 기능 구현

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -178,3 +178,29 @@ export const deleteWithdraw = async () => {
     throw new Error(errorMessage);
   }
 };
+
+export const postTokenReissue = async () => {
+  try {
+    const refreshToken =
+      localStorage.getItem('refreshToken') ||
+      sessionStorage.getItem('refreshToken');
+
+    if (!refreshToken) {
+      throw new Error('리프레시 토큰이 없습니다.');
+    }
+
+    const response = await privateAxios.post(ENDPOINT.AUTH_REISSUE);
+
+    const {accessToken, refreshToken: newRefreshToken} = response.data.data;
+
+    return {
+      accessToken,
+      refreshToken: newRefreshToken,
+    };
+  } catch (error: any) {
+    const code = error.response?.data?.code;
+    const errorMessage = getErrorMessage(code);
+    console.error('Token reissue failed:', error);
+    throw new Error(errorMessage);
+  }
+};

--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -112,8 +112,8 @@ export const postSignupInfo = async (data: SignupInfoType) => {
     const response = await publicAxios.post(ENDPOINT.AUTH_SIGNUP_INFO, data);
     const {accessToken, refreshToken} = response.data.data;
 
-    localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('refreshToken', refreshToken);
+    sessionStorage.setItem('accessToken', accessToken);
+    sessionStorage.setItem('refreshToken', refreshToken);
 
     return response.data.data;
   } catch (error: any) {
@@ -125,13 +125,23 @@ export const postSignupInfo = async (data: SignupInfoType) => {
   }
 };
 
-export const postLogin = async (data: LoginInfoType) => {
+export const postLogin = async (
+  data: LoginInfoType,
+  isStayingLoggedIn: boolean
+) => {
   try {
     const response = await publicAxios.post(ENDPOINT.AUTH_LOGIN, data);
     const {accessToken, refreshToken} = response.data.data;
 
-    localStorage.setItem('accessToken', accessToken);
-    localStorage.setItem('refreshToken', refreshToken);
+    if (isStayingLoggedIn) {
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+      localStorage.setItem('isStayingLoggedIn', 'true');
+    } else {
+      sessionStorage.setItem('accessToken', accessToken);
+      sessionStorage.setItem('refreshToken', refreshToken);
+      localStorage.setItem('isStayingLoggedIn', 'false');
+    }
 
     return response.data.data;
   } catch (error: any) {

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -35,7 +35,12 @@ export const privateAxios = axios.create({
 
 privateAxios.interceptors.request.use(
   (config) => {
-    const accessToken = localStorage.getItem('accessToken');
+    const isStayingLoggedIn =
+      localStorage.getItem('isStayingLoggedIn') === 'true';
+    const accessToken = isStayingLoggedIn
+      ? localStorage.getItem('accessToken')
+      : sessionStorage.getItem('accessToken');
+
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -49,17 +49,92 @@ privateAxios.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-// 토큰 만료 처리
+// 토큰 갱신 중인지 확인하는 플래그
+let isRefreshing = false;
+// 토큰 갱신 중 대기하는 요청들을 저장하는 큐
+let failedQueue: Array<{
+  resolve: (value?: any) => void;
+  reject: (reason?: any) => void;
+}> = [];
+
+/**
+ * 대기 중인 모든 요청을 처리
+ * @param error 에러가 있으면 모든 요청을 reject
+ * @param token 성공하면 새 토큰으로 모든 요청을 resolve
+ */
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach(({resolve, reject}) => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve(token);
+    }
+  });
+
+  failedQueue = [];
+};
+
+/**
+ * 토큰 만료 처리
+ */
 privateAxios.interceptors.response.use(
   (response) => {
     return response;
   },
-  (error) => {
-    if (error.response?.status === 401) {
-      // 토큰 만료 시 로그아웃 처리
-      useAuthStore.getState().logout();
-      window.location.href = '/login';
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 401 에러이고 재시도하지 않은 요청인지 확인
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      const authStore = useAuthStore.getState();
+      const isStayingLoggedIn =
+        localStorage.getItem('isStayingLoggedIn') === 'true';
+
+      // 로그인 유지 옵션이 없으면 로그아웃 후 로그인 페이지로 이동
+      if (!isStayingLoggedIn) {
+        authStore.logout();
+        window.location.href = '/login';
+        return Promise.reject(error);
+      }
+
+      // 토큰 갱신 중인 경우
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({resolve, reject});
+        })
+          .then((token) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            return privateAxios(originalRequest);
+          })
+          .catch((err) => {
+            return Promise.reject(err);
+          });
+      }
+
+      // 토큰 갱신 시도
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const success = await authStore.refreshAccessToken();
+
+        if (success) {
+          const newAccessToken = authStore.accessToken;
+          processQueue(null, newAccessToken);
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          return privateAxios(originalRequest);
+        } else {
+          processQueue(error, null);
+          return Promise.reject(error);
+        }
+      } catch (refreshError) {
+        processQueue(refreshError, null);
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
     }
+
     return Promise.reject(error);
   }
 );

--- a/src/api/mypageApi.ts
+++ b/src/api/mypageApi.ts
@@ -9,7 +9,7 @@ import type {CommentedPostsResponse, MyPostsResponse} from '@/types/community';
 export const getMypageInfo = async () => {
   try {
     const response = await privateAxios.get(ENDPOINT.MYPAGE_INFO);
-    return response.data;
+    return response.data.data;
   } catch (error: any) {
     // const status = error.response.data.status;
     const code = error.response.data.code;

--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -16,6 +16,9 @@ export const ENDPOINT = {
   // login
   AUTH_LOGIN: 'api/v1/auth/login',
 
+  // accessToken 재발급
+  AUTH_REISSUE: 'api/v1/auth/reissue',
+
   // logout
   AUTH_LOGOUT: 'api/v1/auth/logout',
 

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -23,12 +23,15 @@ const LoginPage = () => {
 
   const loginMutation = useMutation({
     mutationFn: async () => {
-      const loginRes = await postLogin({userId: id, password: pw});
+      const loginRes = await postLogin(
+        {userId: id, password: pw},
+        isStayingLoggedIn
+      );
 
       const mypageRes = await getMypageInfo();
       const userInfo = mypageRes;
 
-      login(loginRes.accessToken, loginRes.refreshToken);
+      login(loginRes.accessToken, loginRes.refreshToken, isStayingLoggedIn);
       setUser(userInfo);
       navigate('/');
     },

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -15,7 +15,7 @@ import Modal from '@/components/global/Modal';
 
 const LoginPage = () => {
   const navigate = useNavigate();
-  const {login} = useAuthStore();
+  const {login, setUser} = useAuthStore();
 
   const [isStayingLoggedIn, setIsStayingLoggedIn] = useState(false);
   const [id, setId] = useState('');
@@ -26,9 +26,10 @@ const LoginPage = () => {
       const loginRes = await postLogin({userId: id, password: pw});
 
       const mypageRes = await getMypageInfo();
-      const userInfo = mypageRes.data;
+      const userInfo = mypageRes;
 
-      login(loginRes.accessToken, loginRes.refreshToken, userInfo);
+      login(loginRes.accessToken, loginRes.refreshToken);
+      setUser(userInfo);
       navigate('/');
     },
   });

--- a/src/pages/auth/SignupFormPage.tsx
+++ b/src/pages/auth/SignupFormPage.tsx
@@ -28,7 +28,7 @@ import type {FormState} from '@/types/auth';
 
 const SignupFormPage = () => {
   const navigate = useNavigate();
-  const {login} = useAuthStore();
+  const {login, setUser} = useAuthStore();
 
   const [formState, setFormState] = useState<FormState>({
     id: {value: '', isValid: false, isChecked: false, isAvailable: false},
@@ -176,10 +176,11 @@ const SignupFormPage = () => {
 
       // 3. 마이페이지 정보 가져오기
       const mypageRes = await getMypageInfo();
-      const userInfo = mypageRes.data;
+      const userInfo = mypageRes;
 
       // 4. 모든 단계가 성공했을 때 로그인 처리 및 페이지 이동
-      login(signupRes.accessToken, signupRes.refreshToken, userInfo);
+      login(signupRes.accessToken, signupRes.refreshToken);
+      setUser(userInfo);
       navigate('/signup-complete');
     },
     onError: (error: any) => {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import type {User} from '@/types/auth';
 import {create} from 'zustand';
 import {getMypageInfo} from '@/api/mypageApi';
+import {postTokenReissue} from '@/api/authApi';
 
 export interface AuthState {
   user: User | null;
@@ -117,6 +118,33 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           profileImageUrl: img,
         },
       });
+    }
+  },
+
+  refreshAccessToken: async (): Promise<boolean> => {
+    try {
+      const {accessToken, refreshToken} = await postTokenReissue();
+
+      const currentState = get();
+
+      if (currentState.isStayingLoggedIn) {
+        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
+      } else {
+        sessionStorage.setItem('accessToken', accessToken);
+        sessionStorage.setItem('refreshToken', refreshToken);
+      }
+
+      set({
+        accessToken,
+        refreshToken,
+      });
+
+      return true;
+    } catch (error) {
+      console.error('Token refresh failed:', error);
+      get().logout();
+      return false;
     }
   },
 }));

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -57,7 +57,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (accessToken && refreshToken) {
       try {
         const mypageRes = await getMypageInfo();
-        const userInfo = mypageRes.data;
+        const userInfo = mypageRes;
 
         set({
           accessToken,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -8,7 +8,8 @@ export interface AuthState {
   refreshToken: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
-  login: (accessToken: string, refreshToken: string, user: User) => void;
+  login: (accessToken: string, refreshToken: string) => void;
+  setUser: (user: User) => void;
   logout: () => void;
   checkAuth: () => Promise<void>;
   setProfileImage: (img: string) => void;
@@ -21,15 +22,20 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   isAuthenticated: false,
   isLoading: true,
 
-  login: (accessToken: string, refreshToken: string, user: User) => {
+  login: (accessToken: string, refreshToken: string) => {
     localStorage.setItem('accessToken', accessToken);
     localStorage.setItem('refreshToken', refreshToken);
     set({
       accessToken,
       refreshToken,
-      user,
       isAuthenticated: true,
       isLoading: false,
+    });
+  },
+
+  setUser: (user: User) => {
+    set({
+      user,
     });
   },
 

--- a/src/util/getErrorMessage.ts
+++ b/src/util/getErrorMessage.ts
@@ -10,6 +10,8 @@ const getErrorMessage = (code: string): string => {
       return '아이디 형식이 올바르지 않습니다.';
     case 'AUTH-003':
       return '비밀번호 형식이 올바르지 않습니다.';
+    case 'AUTH-006':
+      return '유효하지 않은 토큰입니다.';
     case 'AUTH-009':
       return '비밀번호가 일치하지 않습니다.';
     case 'AUTH-010':


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#173 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

이 pull request는 토큰 저장, 갱신 로직, 로그인 유지 기능에 중점을 두고 **인증 및 세션 관리에 중요한 개선 사항을 도입**합니다. 이러한 변경 사항은 "로그인 유지" 기능 지원, 강력한 토큰 갱신, 로그인 및 회원가입 과정 전반에 걸친 일관된 사용자 상태 관리를 통해 사용자 경험을 향상합니다.

---

### **인증 및 세션 관리 개선**

- **"로그인 유지" 옵션을 구현**하여 사용자가 세션 기반 로그인과 영구 로그인 중 하나를 선택할 수 있게 되었습니다. 이제 토큰 저장은 사용자 선호도에 따라 `localStorage` 또는 `sessionStorage`를 사용하며, 로그인 플로우는 `isStayingLoggedIn` 플래그를 설정합니다.
- **강력한 토큰 갱신 로직을 추가**했습니다. 새로운 API 엔드포인트(`AUTH_REISSUE`)와 보조 함수를 도입하여 리프레시 토큰을 사용한 액세스 토큰 재발급 기능을 구현했습니다. 이제 `privateAxios` 인스턴스는 401 오류를 처리할 때 토큰 갱신을 시도하고, 갱신 중 실패한 요청을 큐에 넣어 처리합니다.

---

### **상태 관리 및 API 일관성**

- **인증 스토어를 리팩터링**하여 `login`과 `setUser` 액션을 분리했습니다. 이를 통해 로그인 또는 회원가입 성공 후 사용자 데이터가 올바르게 설정되도록 보장합니다. 이제 스토어는 `isStayingLoggedIn` 상태를 추적하고 토큰 갱신을 위한 `refreshAccessToken` 메서드를 제공합니다.
- **사용자 정보 가져오기 API 응답 처리를 업데이트**하여 일관된 데이터 접근을 보장하고 혼동을 줄였습니다.

---

### **오류 처리 개선**

- **유효하지 않은 토큰에 대한 새로운 오류 코드 처리를 추가**하여 사용자에게 더 명확한 피드백을 제공합니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->