### PR TITLE
fix/#176: ui 스타일 수정

### DIFF
--- a/src/components/community/post/CommentInput.tsx
+++ b/src/components/community/post/CommentInput.tsx
@@ -49,7 +49,7 @@ const CommentInput = ({
 
   return (
     <div className='flex items-center justify-between w-full bg-[#EBEBEB] px-8 py-[11px]'>
-      <div className='flex items-center gap-[20px]'>
+      <div className='flex items-center gap-[20px] w-full'>
         {/* TODO: 로그인 시 사용자 프로필 이미지로 대체 */}
         <img
           src='/default-profile.svg'
@@ -68,7 +68,7 @@ const CommentInput = ({
 
       <Send
         onClick={handleSubmit}
-        className={`inline-block ${isSubmitting ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+        className={`inline-block ${isSubmitting ? 'cursor-not-allowed' : 'cursor-pointer'} shrink-0`}
         role='button'
         aria-label='댓글 등록'
       />

--- a/src/components/community/post/PostItem.tsx
+++ b/src/components/community/post/PostItem.tsx
@@ -23,46 +23,60 @@ const PostItem = ({post, onPostClick, onLikeClick, variant}: PostItemProps) => {
   const currentCounts = getCounts(post.id, 'community');
   return (
     <div
-      className='w-full h-55 flex flex-row bg-[#ffffff] px-9 py-6 gap-10 cursor-pointer'
+      className='flex items-center gap-10 w-full bg-[#ffffff] cursor-pointer'
       onClick={onPostClick}>
-      <div className='flex-1 flex flex-col justify-center'>
+      {/* title */}
+      <div className='flex flex-col flex-1'>
         {variant === 'hot' ? (
-          <div className='truncate text-md sm:max-w-250 max-w-100'>
-            {post.title}
-          </div>
+          <div className='line-clamp-1 text-md'>{post.title}</div>
         ) : (
-          <div className='text-md truncate sm:max-w-400 max-w-200'>
-            {post.title}
-          </div>
-        )}
-        {/**
-         * variant가 핫이 아닐 때만 날짜 렌더링
-         * 날짜 로직 수정 todo
-         * 24시간 이내일 경우 -> 시간 렌더링
-         * 그 외 -> 월/일 렌더링
-         */}
-        {variant !== 'hot' && (
-          <div className='text-sm text-gray-2'>{post.createdAt}</div>
+          <>
+            <div className='text-md line-clamp-1'>{post.title}</div>
+            <div className='text-sm text-gray-2'>{post.createdAt}</div>
+            {/* [24시간 이내: 시간], [그 외: 월/일] */}
+          </>
         )}
       </div>
 
-      <div
-        className={`flex flex-col ${variant === 'hot' ? 'justify-center' : 'justify-end'} items-end h-full`}>
-        <div className='flex flex-row gap-3 items-center text-sm'>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onLikeClick?.();
-            }}>
-            {isCurrentlyLiked ? (
-              <FullHeart width={20} height={20} />
-            ) : (
-              <EmptyHeart className='stroke-secondary' width={20} height={20} />
-            )}
-          </button>
-          <span>{currentCounts.likeCount}</span>
-          <Chat className='text-secondary ml-14 w-20 mb-[1px]' />
-          <span>{currentCounts.commentCount}</span>
+      {/* count */}
+      <div className={`flex flex-col items-end`}>
+        <div className='flex justify-end items-center text-sm'>
+          <div className='flex gap-14 '>
+            {/* heart */}
+            <div className='flex items-center gap-2 w-46'>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onLikeClick?.();
+                }}
+                className='m-[2.5px]'>
+                {isCurrentlyLiked ? (
+                  <FullHeart width={20} height={20} />
+                ) : (
+                  <EmptyHeart
+                    className='stroke-secondary'
+                    width={20}
+                    height={20}
+                  />
+                )}
+              </button>
+              <span>
+                {currentCounts.likeCount > 99 ? '99+' : currentCounts.likeCount}
+              </span>
+            </div>
+
+            {/* comment */}
+            <div className='flex items-center gap-2 w-46'>
+              <div className=' m-[2.5px]'>
+                <Chat className='text-secondary w-20' />
+              </div>
+              <span>
+                {currentCounts.commentCount > 99
+                  ? '99+'
+                  : currentCounts.commentCount}
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/community/post/PostList.tsx
+++ b/src/components/community/post/PostList.tsx
@@ -34,7 +34,8 @@ const PostList = ({icon, title, variant}: PostListProps) => {
   const [loading, setLoading] = useState(true);
   const {goToCommunityCategory} = useCommunityListNavigation();
   const {goToPostDetail} = useCommunityNavigation();
-  const {initializeFromServer, isLiked, toggleLike, getCounts, setCounts} = useScrapStore();
+  const {initializeFromServer, isLiked, toggleLike, getCounts, setCounts} =
+    useScrapStore();
 
   useEffect(() => {
     const fetchPosts = async () => {
@@ -73,9 +74,9 @@ const PostList = ({icon, title, variant}: PostListProps) => {
         }));
 
         setPosts(mappedPosts);
-        
+
         // 전역 상태 초기화
-        const stateInitData = mappedPosts.map(post => ({
+        const stateInitData = mappedPosts.map((post) => ({
           id: post.id,
           type: 'community' as const,
           isLiked: post.isLiked,
@@ -85,7 +86,6 @@ const PostList = ({icon, title, variant}: PostListProps) => {
           commentCount: post.commentCount,
         }));
         initializeFromServer(stateInitData);
-        
       } catch (error) {
         console.error(`${title} 조회 실패`, error);
       } finally {
@@ -103,14 +103,16 @@ const PostList = ({icon, title, variant}: PostListProps) => {
   const handleLike = (post: Post) => async () => {
     const currentCounts = getCounts(post.id, 'community');
     const isCurrentlyLiked = isLiked(post.id, 'community');
-    
+
     // 즉시 전역 상태 업데이트
     toggleLike(post.id, 'community');
     setCounts(post.id, 'community', {
       ...currentCounts,
-      likeCount: isCurrentlyLiked ? currentCounts.likeCount - 1 : currentCounts.likeCount + 1,
+      likeCount: isCurrentlyLiked
+        ? currentCounts.likeCount - 1
+        : currentCounts.likeCount + 1,
     });
-    
+
     // 로컬 상태도 동기화
     setPosts((prevPosts) =>
       prevPosts.map((p) =>
@@ -178,11 +180,12 @@ const PostList = ({icon, title, variant}: PostListProps) => {
       </div>
 
       {variant === 'hot' ? (
-        <div className='bg-[#fff] rounded-[20px] w-full px-20 py-7 flex flex-col gap-4 border border-primary-4'>
+        // hot 게시물
+        <div className='bg-[#fff] rounded-[20px] w-full p-18 flex flex-col gap-21 border border-primary-4'>
           {posts.map((post) => (
             <div
               key={post.uniqueKey}
-              className='flex flex-row gap-10 pb-4 cursor-pointer items-center'
+              className='flex items-center gap-10 cursor-pointer'
               onClick={handleClick(post)}>
               {/* 카테고리명 + 게시판 표시 */}
               <h1 className='font-semibold text-[18px] whitespace-nowrap shrink-0'>
@@ -190,6 +193,7 @@ const PostList = ({icon, title, variant}: PostListProps) => {
                   ? `${post.category}게시판`
                   : post.category}
               </h1>
+
               {/* 게시물 내용 */}
               <PostItem
                 post={post}
@@ -201,14 +205,12 @@ const PostList = ({icon, title, variant}: PostListProps) => {
           ))}
         </div>
       ) : (
-        /** 일상, 꿀팁 게시물 */
-        <div className='bg-[#fff] rounded-[20px] w-full p-5 flex flex-col gap-4'>
+        // 일상, 꿀팁 게시물
+        <div className='bg-[#fff] rounded-[20px] w-full p-10 flex flex-col gap-4'>
           {posts.map((post, idx) => (
             <div
               key={post.uniqueKey}
-              className={`pb-4 ${
-                idx !== posts.length - 1 ? 'border-b border-primary-5' : ''
-              }`}>
+              className={`${idx !== posts.length - 1 ? 'border-b border-primary-5' : ''} `}>
               <PostItem
                 post={post}
                 onPostClick={handleClick(post)}

--- a/src/components/modal/SelectDateModal.tsx
+++ b/src/components/modal/SelectDateModal.tsx
@@ -52,7 +52,7 @@ const SelectDateModal = ({onClick}: SelectDateModalProps) => {
 
   return (
     <div className='fixed sm:bottom-[60px] bottom-[45px] left-0 w-full flex justify-center items-end z-50'>
-      <div className='sm:w-full sm:h-[302px] h-200 bg-white rounded-t-[20px] flex flex-col items-center justify-between px-10 sm:pb-40 pb-10 sm:pt-20 pt-10 font-roboto shadow-sm'>
+      <div className='w-full sm:h-[302px] h-200 bg-white rounded-t-[20px] flex flex-col items-center justify-between px-10 sm:pb-40 pb-10 sm:pt-20 pt-10 font-roboto shadow-sm'>
         {/* 상단 드래그 바 */}
         <div className='sm:w-[200px] w-100 h-[6px] bg-[#D9D9D9] rounded-full mb-4' />
 

--- a/src/pages/calendar/CalendarPage.tsx
+++ b/src/pages/calendar/CalendarPage.tsx
@@ -331,7 +331,7 @@ const CalendarPage = () => {
       {isModalOpen && (
         <>
           <div
-            className='fixed top-[65px] left-1/2 -translate-x-1/2 w-[600px] h-[500px] bg-gray-3/10 z-40 rounded-[10px]'
+            className='fixed w-full m-auto left-1/2 -translate-x-1/2 max-w-[600px] h-full sm:bottom-[362px] bottom-245 bg-gray-3/10 z-40 rounded-[10px]'
             onClick={closeModal}
           />
 


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#176 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->

이 pull request는 코드베이스 내 여러 커뮤니티 관련 컴포넌트의 **레이아웃, 스타일, 사용성을 개선**하는 데 중점을 둡니다. 주요 변경 사항은 시각적 일관성, 반응형 디자인, 그리고 소규모 코드 정리 작업으로, UI를 더욱 세련되고 사용자 친화적으로 만듭니다.

---

### **커뮤니티 게시물 목록 및 아이템 레이아웃 개선**

- `PostItem` 및 `PostList` 컴포넌트를 리팩터링하여 **더 일관된 플렉스 레이아웃과 개선된 간격 및 패딩 값**을 적용했습니다. 제목과 개수 같은 요소들이 적절히 잘리고 정렬되도록 보장합니다. 게시물 개수는 가독성을 위해 "99+"로 상한선이 설정됩니다.
- 게시물 날짜와 댓글 렌더링 로직을 업데이트하여 "인기" 게시물과 일반 게시물 간의 구분이 더 명확해졌으며, 표시되는 날짜 형식 처리도 개선되었습니다.

---

### **반응형 및 시각적 개선**

- 모달과 캘린더 오버레이 레이아웃을 **완전한 반응형으로 조정**하여 다양한 화면 크기에서 올바른 크기와 위치를 유지하도록 했습니다.
- 댓글 입력 영역을 개선하여 가용 너비를 더 잘 활용하고 요소들의 일관된 정렬을 유지하도록 했습니다.

---

### **소규모 코드 정리 및 일관성**

- 코드 가독성 및 유지보수성을 높이기 위해 **함수 포맷팅 및 변수 명명 규칙을 표준화**했습니다.

이러한 변경 사항은 커뮤니티 컴포넌트의 사용자 경험과 유지보수성을 총체적으로 향상시킵니다.

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

- 날짜 선택 모달 스타일 수정.
  반응형으로 작은 상태일 때 모달이 가운데에만 위치해서 가로로 화면에 차도록 수정했습니다. 

- 커뮤니티 게시판 목록 스타일 수정.
  게시판의 게시글 제목들이 전부 나오지 않아서 전부 나오도록 수정했습니다. 

- CommentInput 컴포넌트 스타일 수정.
  댓글 입력창에서 댓글창 끝까지 글씨가 입력되지 않아서 끝까지 입력되도록 수정했습니다. 


<br><br>
## 🔗 Reference
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) -->